### PR TITLE
Add SSL verification and chat model support for LiteLLM provider

### DIFF
--- a/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
@@ -16,6 +16,7 @@ class LiteLLMCompatibleChatModel(ChatModel):
             LLMProviderProperty("base_url", "Base URL", "Base URL", "", False),
             LLMProviderProperty("api_key", "API key", "API key", "", True),
             LLMProviderProperty("context_window", "Context window", "Context window length", "", True),
+            LLMProviderProperty("verify_ssl", "Verify SSL", "Verify SSL certificates (disable for self-signed certificates)", "true", True),
         ]
 
     @property
@@ -42,6 +43,16 @@ class LiteLLMCompatibleChatModel(ChatModel):
         base_url = self.get_property("base_url").value
         api_key_prop = self.get_property("api_key")
         api_key = api_key_prop.value if api_key_prop is not None else None
+
+        # Read SSL verification setting (default to True for security)
+        verify_ssl_prop = self.get_property("verify_ssl")
+        verify_ssl = True
+        if verify_ssl_prop is not None and verify_ssl_prop.value:
+            verify_ssl = verify_ssl_prop.value.lower() not in ('false', '0', 'no', 'off')
+
+        # Set SSL verification on litellm module
+        litellm.ssl_verify = verify_ssl
+
         litellm_resp = litellm.completion(
             model=model_id,
             messages=messages.copy(),
@@ -77,6 +88,7 @@ class LiteLLMCompatibleInlineCompletionModel(InlineCompletionModel):
             LLMProviderProperty("base_url", "Base URL", "Base URL", "", False),
             LLMProviderProperty("api_key", "API key", "API key", "", True),
             LLMProviderProperty("context_window", "Context window", "Context window length", "", True),
+            LLMProviderProperty("verify_ssl", "Verify SSL", "Verify SSL certificates (disable for self-signed certificates)", "true", True),
         ]
 
     @property
@@ -102,16 +114,62 @@ class LiteLLMCompatibleInlineCompletionModel(InlineCompletionModel):
         base_url = self.get_property("base_url").value
         api_key_prop = self.get_property("api_key")
         api_key = api_key_prop.value if api_key_prop is not None else None
-        litellm_resp = litellm.completion(
-            model=model_id,
-            prompt=prefix,
-            suffix=suffix,
-            stream=False,
-            api_base=base_url,
-            api_key=api_key,
-        )
 
-        return litellm_resp.choices[0].message.content
+        # Read SSL verification setting (default to True for security)
+        verify_ssl_prop = self.get_property("verify_ssl")
+        verify_ssl = True
+        if verify_ssl_prop is not None and verify_ssl_prop.value:
+            verify_ssl = verify_ssl_prop.value.lower() not in ('false', '0', 'no', 'off')
+
+        # Set SSL verification on litellm module
+        litellm.ssl_verify = verify_ssl
+
+        # Try FIM format first (for models that support fill-in-the-middle)
+        try:
+            litellm_resp = litellm.completion(
+                model=model_id,
+                prompt=prefix,
+                suffix=suffix,
+                stream=False,
+                api_base=base_url,
+                api_key=api_key,
+            )
+            return litellm_resp.choices[0].message.content
+        except Exception as e:
+            # Fall back to chat format for models that don't support FIM
+            prompt_text = f"You are an autocomplete engine. Complete the {language} code at the cursor position. "
+            prompt_text += f"Return ONLY the raw code to insert at the cursor. No markdown, no code blocks, no explanations.\n\n"
+            prompt_text += f"Code before cursor:\n{prefix}\n\n"
+            if suffix:
+                prompt_text += f"Code after cursor:\n{suffix}\n\n"
+            prompt_text += "Complete the code at the cursor position with ONLY raw code:"
+
+            messages = [
+                {"role": "user", "content": prompt_text}
+            ]
+
+            litellm_resp = litellm.completion(
+                model=model_id,
+                messages=messages,
+                stream=False,
+                api_base=base_url,
+                api_key=api_key,
+            )
+
+            completion = litellm_resp.choices[0].message.content
+
+            # Strip markdown code blocks if present
+            if completion.startswith("```"):
+                # Remove opening code fence
+                lines = completion.split("\n")
+                if lines[0].startswith("```"):
+                    lines = lines[1:]
+                # Remove closing code fence
+                if lines and lines[-1].strip() == "```":
+                    lines = lines[:-1]
+                completion = "\n".join(lines)
+
+            return completion
 
 class LiteLLMCompatibleLLMProvider(LLMProvider):
     def __init__(self):


### PR DESCRIPTION
## Summary
This PR adds two improvements to the LiteLLM compatible provider:
1. Configurable SSL verification for self-signed certificates
2. Support for chat-only models (like Anthropic) in inline completions

Fixes #128
Fixes #129

## Changes

### SSL Verification (Issue #128)
- Added `verify_ssl` property to both `LiteLLMCompatibleChatModel` and `LiteLLMCompatibleInlineCompletionModel`
- Defaults to `true` (secure by default)
- Sets `litellm.ssl_verify` module setting before API calls
- Allows users with self-signed certificates to opt-in by setting `"verify_ssl": "false"` in their config

### Chat Model Support for Inline Completions (Issue #129)
- Implemented fallback mechanism: tries FIM format first, falls back to chat format
- Maintains backward compatibility with FIM-capable models (OpenAI Codex, etc.)
- Adds support for chat-only models like Anthropic Claude
- Strips markdown code blocks from chat model responses

## Testing
Tested with:
- Anthropic Claude via LiteLLM proxy with self-signed certificate
- Inline chat (Ctrl+G) - working ✅
- Sidebar chat - working ✅
- Autocomplete/inline completions - working ✅

## Backward Compatibility
- `verify_ssl` is optional and defaults to `true` (secure)
- FIM format is tried first for existing setups
- No breaking changes to existing configurations

## Usage Example

For users with self-signed certificates, add to your config:

```json
{
  "chat_model": {
    "properties": [
      ...
      {
        "id": "verify_ssl",
        "name": "Verify SSL",
        "description": "Verify SSL certificates (disable for self-signed certificates)",
        "value": "false",
        "optional": true
      }
    ]
  }
}