### PR TITLE
feat(telemetry): track inline-completion and inline-chat acceptance separately

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -62,9 +62,9 @@ The encrypted GitHub token uses a default password (`nbi-access-token-password`)
 
 ## Telemetry
 
-NBI does not collect telemetry, send analytics, or report usage.
+NBI has no central server and sends no telemetry, analytics, or usage data to any external service.
 
-The `enable_chat_feedback` traitlet (off by default) emits an internal `telemetry` event when a user gives thumbs-up/down feedback in chat. The event is **emitted in-process only** — nothing leaves the process unless you write a custom handler that listens for it. See [`docs/admin-guide.md`](docs/admin-guide.md#chat-feedback-event-hook).
+Internally, NBI emits `telemetry` events that signal feature usage: chat, inline completion, and cell inline chat lifecycle events (including when a suggestion is accepted or dismissed), plus thumbs-up/down chat feedback when `enable_chat_feedback` is on. These events are **emitted in-process only**. By default nothing listens for them, so they go nowhere and never leave the process; an administrator can register a listener to collect them. See [`docs/admin-guide.md`](docs/admin-guide.md#telemetry-events).
 
 ## Reproducibility caveat
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ c.NotebookIntelligence.enable_chat_feedback = True
 jupyter lab --NotebookIntelligence.enable_chat_feedback=true
 ```
 
-The feedback fires an in-process `telemetry` event. Nothing leaves the process by default — see the [admin guide](docs/admin-guide.md#chat-feedback-event-hook) for how to wire it into your observability stack.
+The feedback fires an in-process `telemetry` event. Nothing leaves the process by default. See the [admin guide](docs/admin-guide.md#telemetry-events) for the full set of telemetry events and how to wire them into your observability stack.
 
 The thumbs buttons reveal on hover by default. To keep them always visible, enable:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -21,7 +21,7 @@ This guide covers deploying Notebook Intelligence at scale — JupyterHub, KubeS
 - [Restricting features for managed deployments](#restricting-features-for-managed-deployments)
 - [Multi-tenancy and per-team scoping](#multi-tenancy-and-per-team-scoping)
 - [Managed Claude Skills token](#managed-claude-skills-token)
-- [Chat feedback event hook](#chat-feedback-event-hook)
+- [Telemetry events](#telemetry-events)
 - [HTTP API surface](#http-api-surface)
 - [Failure modes](#failure-modes)
 - [Version matrix](#version-matrix)
@@ -643,13 +643,43 @@ The reconciler handles skill name collisions between manifests and user-authored
 
 ---
 
-## Chat feedback event hook
+## Telemetry events
 
-When `enable_chat_feedback = True`, NBI emits a `telemetry` event in-process whenever a user gives thumbs-up/down feedback in chat. The event payload includes the rating, the prompt, the response, and the model.
+NBI emits `telemetry` events in-process to signal feature usage. The events are **emitted in-process only**: by default nothing listens for them, so they go nowhere and never leave the process. To collect them (for example, to forward usage into an internal observability stack such as Kafka or an OTel collector), write a JupyterLab extension that registers a listener through NBI's `INotebookIntelligence` token and forwards what it receives. Payload shapes are not currently considered stable API; if you build on them, pin to a specific NBI version.
 
-The event is **emitted in-process only**. Nothing leaves the process unless you write a custom handler that listens for it. The payload shape is not currently considered stable API; if you build on it, pin to a specific NBI version.
+Each event has a `type` (the identifier below) and a `data` payload carrying the relevant model and context. Auto-complete (inline completion) and cell inline chat are reported as separate event families, so a listener can tell the two features apart by `type` alone.
 
-To pipe feedback into your internal observability stack (Kafka, OTel collector), write an extension that registers a listener for the `telemetry` event and forwards it.
+Auto-complete:
+
+| Event `type`                 | Fires when                                                    |
+| ---------------------------- | ------------------------------------------------------------- |
+| `inline-completion-request`  | A ghost-text completion is requested as the user types.       |
+| `inline-completion-response` | A suggestion is returned (carries `timeElapsed`).             |
+| `inline-completion-accepted` | The user accepts a suggestion (Tab or the completer toolbar). |
+
+Cell inline chat:
+
+| Event `type`            | Fires when                                                          |
+| ----------------------- | ------------------------------------------------------------------- |
+| `inline-chat-request`   | The user submits an inline-chat prompt (carries the `prompt`).      |
+| `inline-chat-response`  | A generation completes (carries `timeElapsed`).                     |
+| `inline-chat-accepted`  | Generated code is applied, with `mode` = `review` or `auto-insert`. |
+| `inline-chat-dismissed` | The popover is closed after code was shown but never applied.       |
+
+Chat and feedback:
+
+| Event `type`                     | Fires when                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------ |
+| `chat-request` / `chat-response` | A message is sent to / answered by the chat sidebar.                                       |
+| `feedback`                       | The user gives thumbs-up/down on a chat response (`sentiment` = `positive` or `negative`). |
+
+NBI also emits request events for the chat sidebar's code and output actions (`generate-code-request`, `explain-this-request`, `fix-this-code-request`, `explain-this-output-request`, `troubleshoot-this-output-request`, `output-follow-up-request`).
+
+The `inline-completion-*`, `inline-chat-*`, and chat/action events fire whenever those features are used; they are not gated by any setting. To measure how often auto-complete suggestions are taken, compare `inline-completion-accepted` against `inline-completion-response`; the gap is the ignore rate. Only the `feedback` event is gated, by `enable_chat_feedback` (off by default), which also controls the thumbs-up/down UI:
+
+```python
+c.NotebookIntelligence.enable_chat_feedback = True
+```
 
 The thumbs buttons reveal on hover by default. To keep them always visible, enable:
 
@@ -663,40 +693,40 @@ c.NotebookIntelligence.enable_chat_feedback_always_visible = True
 
 All routes live under `/notebook-intelligence/`. All require Jupyter authentication (XSRF token plus Jupyter login token) including the `/copilot` WebSocket upgrade, which now inherits Jupyter's `WebSocketMixin` + `JupyterHandler` so the same `allow_origin` and identity-provider checks that apply to REST handlers also apply to the chat WS endpoint. The labextension obtains these automatically. There is no admin-only route; access control runs through Jupyter Server itself.
 
-| Route                                                       | Method          | Purpose                                                                                                              |
-| ----------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `/notebook-intelligence/capabilities`                       | GET             | Capabilities + tool/provider gate state.                                                                             |
-| `/notebook-intelligence/config`                             | GET/POST        | Read or update user-scope config.                                                                                    |
-| `/notebook-intelligence/update-provider-models`             | POST            | Refresh model list for a provider (e.g., Anthropic SDK refresh).                                                     |
-| `/notebook-intelligence/mcp-config-file`                    | GET/POST        | Read or write `~/.jupyter/nbi/mcp.json`.                                                                             |
-| `/notebook-intelligence/reload-mcp-servers`                 | POST            | Re-discover MCP servers without restarting JupyterLab.                                                               |
-| `/notebook-intelligence/emit-telemetry-event`               | POST            | Used by the frontend to emit `telemetry` events (e.g., chat feedback).                                               |
-| `/notebook-intelligence/gh-login-status`                    | GET             | GitHub Copilot login state.                                                                                          |
-| `/notebook-intelligence/gh-login`                           | POST            | Begin GitHub Copilot device-flow login.                                                                              |
-| `/notebook-intelligence/gh-logout`                          | GET             | Sign out of GitHub Copilot.                                                                                          |
-| `/notebook-intelligence/copilot`                            | WS              | Streaming chat / inline-completion WebSocket.                                                                        |
-| `/notebook-intelligence/rules`                              | GET             | List discovered rules.                                                                                               |
-| `/notebook-intelligence/rules/<id>/toggle`                  | PUT             | Toggle a rule's `active` field.                                                                                      |
-| `/notebook-intelligence/rules/reload`                       | POST            | Manually reload all rules.                                                                                           |
-| `/notebook-intelligence/skills`                             | GET/POST        | List or create skills.                                                                                               |
-| `/notebook-intelligence/skills/context`                     | GET             | Skill context info for the active workspace.                                                                         |
-| `/notebook-intelligence/skills/import/preview`              | POST            | Preview a GitHub-hosted skill before installing.                                                                     |
-| `/notebook-intelligence/skills/import`                      | POST            | Install a GitHub-hosted skill (user-initiated).                                                                      |
-| `/notebook-intelligence/skills/reconcile`                   | POST            | Run the managed-skills reconciler. Returns 409 if `NBI_SKILLS_MANIFEST` is unset.                                    |
-| `/notebook-intelligence/skills/reconciler/stop`             | POST            | Incident-response kill switch. Stops the background reconciler without a server restart. Idempotent.                 |
-| `/notebook-intelligence/skills/<scope>/<name>`              | GET/PUT/DELETE  | Skill detail; managed skills are read-only.                                                                          |
-| `/notebook-intelligence/skills/<scope>/<name>/rename`       | POST            | Rename a skill (denied for managed skills).                                                                          |
-| `/notebook-intelligence/skills/<scope>/<name>/files`        | GET/POST/DELETE | Skill bundle file ops.                                                                                               |
-| `/notebook-intelligence/skills/<scope>/<name>/files/rename` | POST            | Rename a file inside a skill bundle.                                                                                 |
-| `/notebook-intelligence/upload-file`                        | POST            | Upload a file to attach as chat context (size and retention governed by `upload_max_mb` / `upload_retention_hours`). |
-| `/notebook-intelligence/claude-sessions`                    | GET             | List Claude Code sessions for the working directory.                                                                 |
-| `/notebook-intelligence/claude-sessions/resume`             | POST            | Resume a Claude session.                                                                                             |
-| `/notebook-intelligence/claude-mcp`                         | GET/POST        | List or add Claude-mode MCP servers. Gated by `claude_mcp_management_policy`.                                        |
-| `/notebook-intelligence/claude-mcp/<scope>/<name>`          | GET/DELETE      | Get or remove a Claude-mode MCP server by scope (user/project/local) and name.                                       |
-| `/notebook-intelligence/plugins`                            | GET/POST        | List or install Claude plugins. Gated by `claude_plugins_management_policy`.                                         |
-| `/notebook-intelligence/plugins/<scope>/<name>`             | POST/DELETE     | Enable or disable (POST with `{"action": "enable"\|"disable"}`) or uninstall (DELETE) a plugin.                      |
-| `/notebook-intelligence/plugins/marketplace`                | GET/POST        | List or add plugin marketplaces. GitHub-sourced adds are gated by `allow_github_plugin_import`.                      |
-| `/notebook-intelligence/plugins/marketplace/<name>`         | DELETE          | Remove a plugin marketplace.                                                                                         |
+| Route                                                       | Method          | Purpose                                                                                                                                              |
+| ----------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/notebook-intelligence/capabilities`                       | GET             | Capabilities + tool/provider gate state.                                                                                                             |
+| `/notebook-intelligence/config`                             | GET/POST        | Read or update user-scope config.                                                                                                                    |
+| `/notebook-intelligence/update-provider-models`             | POST            | Refresh model list for a provider (e.g., Anthropic SDK refresh).                                                                                     |
+| `/notebook-intelligence/mcp-config-file`                    | GET/POST        | Read or write `~/.jupyter/nbi/mcp.json`.                                                                                                             |
+| `/notebook-intelligence/reload-mcp-servers`                 | POST            | Re-discover MCP servers without restarting JupyterLab.                                                                                               |
+| `/notebook-intelligence/emit-telemetry-event`               | POST            | Used by the frontend to emit `telemetry` events (chat feedback, inline completion and inline chat usage). See [Telemetry events](#telemetry-events). |
+| `/notebook-intelligence/gh-login-status`                    | GET             | GitHub Copilot login state.                                                                                                                          |
+| `/notebook-intelligence/gh-login`                           | POST            | Begin GitHub Copilot device-flow login.                                                                                                              |
+| `/notebook-intelligence/gh-logout`                          | GET             | Sign out of GitHub Copilot.                                                                                                                          |
+| `/notebook-intelligence/copilot`                            | WS              | Streaming chat / inline-completion WebSocket.                                                                                                        |
+| `/notebook-intelligence/rules`                              | GET             | List discovered rules.                                                                                                                               |
+| `/notebook-intelligence/rules/<id>/toggle`                  | PUT             | Toggle a rule's `active` field.                                                                                                                      |
+| `/notebook-intelligence/rules/reload`                       | POST            | Manually reload all rules.                                                                                                                           |
+| `/notebook-intelligence/skills`                             | GET/POST        | List or create skills.                                                                                                                               |
+| `/notebook-intelligence/skills/context`                     | GET             | Skill context info for the active workspace.                                                                                                         |
+| `/notebook-intelligence/skills/import/preview`              | POST            | Preview a GitHub-hosted skill before installing.                                                                                                     |
+| `/notebook-intelligence/skills/import`                      | POST            | Install a GitHub-hosted skill (user-initiated).                                                                                                      |
+| `/notebook-intelligence/skills/reconcile`                   | POST            | Run the managed-skills reconciler. Returns 409 if `NBI_SKILLS_MANIFEST` is unset.                                                                    |
+| `/notebook-intelligence/skills/reconciler/stop`             | POST            | Incident-response kill switch. Stops the background reconciler without a server restart. Idempotent.                                                 |
+| `/notebook-intelligence/skills/<scope>/<name>`              | GET/PUT/DELETE  | Skill detail; managed skills are read-only.                                                                                                          |
+| `/notebook-intelligence/skills/<scope>/<name>/rename`       | POST            | Rename a skill (denied for managed skills).                                                                                                          |
+| `/notebook-intelligence/skills/<scope>/<name>/files`        | GET/POST/DELETE | Skill bundle file ops.                                                                                                                               |
+| `/notebook-intelligence/skills/<scope>/<name>/files/rename` | POST            | Rename a file inside a skill bundle.                                                                                                                 |
+| `/notebook-intelligence/upload-file`                        | POST            | Upload a file to attach as chat context (size and retention governed by `upload_max_mb` / `upload_retention_hours`).                                 |
+| `/notebook-intelligence/claude-sessions`                    | GET             | List Claude Code sessions for the working directory.                                                                                                 |
+| `/notebook-intelligence/claude-sessions/resume`             | POST            | Resume a Claude session.                                                                                                                             |
+| `/notebook-intelligence/claude-mcp`                         | GET/POST        | List or add Claude-mode MCP servers. Gated by `claude_mcp_management_policy`.                                                                        |
+| `/notebook-intelligence/claude-mcp/<scope>/<name>`          | GET/DELETE      | Get or remove a Claude-mode MCP server by scope (user/project/local) and name.                                                                       |
+| `/notebook-intelligence/plugins`                            | GET/POST        | List or install Claude plugins. Gated by `claude_plugins_management_policy`.                                                                         |
+| `/notebook-intelligence/plugins/<scope>/<name>`             | POST/DELETE     | Enable or disable (POST with `{"action": "enable"\|"disable"}`) or uninstall (DELETE) a plugin.                                                      |
+| `/notebook-intelligence/plugins/marketplace`                | GET/POST        | List or add plugin marketplaces. GitHub-sourced adds are gated by `allow_github_plugin_import`.                                                      |
+| `/notebook-intelligence/plugins/marketplace/<name>`         | DELETE          | Remove a plugin marketplace.                                                                                                                         |
 
 The extension respects `c.ServerApp.base_url`. Behind JupyterHub at `/user/<name>/` everything still works because JupyterLab proxies routes through the per-user base URL automatically.
 

--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -909,7 +909,10 @@ class TelemetryEventType(str, Enum):
     InlineChatRequest = 'inline-chat-request'
     ChatResponse = 'chat-response'
     InlineChatResponse = 'inline-chat-response'
+    InlineChatAccepted = 'inline-chat-accepted'
+    InlineChatDismissed = 'inline-chat-dismissed'
     InlineCompletionResponse = 'inline-completion-response'
+    InlineCompletionAccepted = 'inline-completion-accepted'
     Feedback = 'feedback'
 
 class TelemetryEvent:

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ import {
   IInlineCompletionContext,
   IInlineCompletionItem,
   IInlineCompletionList,
-  IInlineCompletionProvider
+  IInlineCompletionProvider,
+  IInlineCompleterFactory
 } from '@jupyterlab/completer';
 
 import { NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
@@ -81,6 +82,10 @@ import {
 import { CellOutputHoverToolbar } from './cell-output-toolbar';
 import { attachOpenFileRefreshWatcher } from './open-file-refresh-watcher';
 import { buildRefreshWatcherEnv } from './open-file-refresh-watcher-env';
+import {
+  wrapInlineCompleterFactory,
+  NBI_INLINE_COMPLETION_PROVIDER_ID
+} from './inline-completer-telemetry';
 import {
   BackendMessageType,
   GITHUB_COPILOT_PROVIDER_ID,
@@ -660,7 +665,7 @@ class NBIInlineCompletionProvider
   }
 
   get identifier(): string {
-    return '@plmbr/notebook-intelligence';
+    return NBI_INLINE_COMPLETION_PROVIDER_ID;
   }
 
   get icon(): LabIcon.ILabIcon {
@@ -841,7 +846,8 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
   optional: [
     IStatusBar,
     ILauncher,
-    ITerminalTracker as unknown as Token<unknown>
+    ITerminalTracker as unknown as Token<unknown>,
+    IInlineCompleterFactory
   ],
   provides: INotebookIntelligence,
   activate: async (
@@ -854,7 +860,8 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     mainMenu: IMainMenu,
     statusBar: IStatusBar | null,
     launcher: ILauncher | null,
-    terminalTracker: ITerminalTracker | null
+    terminalTracker: ITerminalTracker | null,
+    defaultInlineCompleterFactory: IInlineCompleterFactory | null
   ) => {
     console.log(
       'JupyterLab extension @plmbr/notebook-intelligence is activated!'
@@ -909,6 +916,33 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     completionManager.registerInlineProvider(
       new NBIInlineCompletionProvider(telemetryEmitter)
     );
+
+    // Wrap JupyterLab's default inline-completer factory to add acceptance
+    // telemetry. We install it on app.started: that resolves after every
+    // plugin has activated (so JupyterLab's own factory is already set and we
+    // win as the last writer) but before layout restoration creates the per
+    // editor completer handlers, which capture the factory at creation time and
+    // are never regenerated afterwards. Deferring to app.restored would be too
+    // late: the restored notebook's handler would already hold the default
+    // widget. Guarded on the optional factory so NBI still loads if JupyterLab
+    // ever stops providing it (acceptance telemetry simply won't be emitted).
+    if (defaultInlineCompleterFactory) {
+      const wrappedFactory = wrapInlineCompleterFactory(
+        defaultInlineCompleterFactory,
+        telemetryEmitter,
+        () => ({
+          provider: NBIAPI.config.inlineCompletionModel.provider,
+          model: NBIAPI.config.inlineCompletionModel.model
+        })
+      );
+      app.started
+        .then(() => {
+          completionManager.setInlineCompleterFactory(wrappedFactory);
+        })
+        .catch(() => {
+          /* best-effort: acceptance telemetry just won't be emitted */
+        });
+    }
 
     // JL plugins have no deactivate hook, so the watcher runs for the
     // lifetime of the Lab session and the returned teardown is intentionally
@@ -2085,6 +2119,17 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
       let blockPromptView: EditorView | null = null;
       let removed = false;
+      // Acceptance telemetry state: whether generated code was ever shown to
+      // the user, and whether they applied it. A teardown that happens after
+      // code was shown but never applied is a dismissal.
+      let generatedCodeShown = false;
+      let codeApplied = false;
+      // A backend stream error surfaces a visible [Stream interrupted] marker
+      // but no usable code, so tearing the popover down afterwards is a failure,
+      // not a user dismissal. Tracked separately from generatedCodeShown because
+      // the review path re-renders the marker into the diff (which re-sets
+      // generatedCodeShown) after the stream-end callback has run.
+      let streamErrored = false;
       const removePopover = () => {
         // Cleared outside the `removed` guard so the auto-insert path's
         // second call still removes the class added between calls.
@@ -2097,6 +2142,18 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         }
         removed = true;
         closeOpenPopover = null;
+
+        if (generatedCodeShown && !codeApplied && !streamErrored) {
+          telemetryEmitter.emitTelemetryEvent({
+            type: TelemetryEventType.InlineChatDismissed,
+            data: {
+              chatModel: {
+                provider: NBIAPI.config.chatModel.provider,
+                model: NBIAPI.config.chatModel.model
+              }
+            }
+          });
+        }
 
         if (blockPromptView) {
           blockPromptView.dispatch({
@@ -2136,6 +2193,19 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       }
 
       const applyGeneratedCode = () => {
+        codeApplied = true;
+        telemetryEmitter.emitTelemetryEvent({
+          type: TelemetryEventType.InlineChatAccepted,
+          data: {
+            chatModel: {
+              provider: NBIAPI.config.chatModel.provider,
+              model: NBIAPI.config.chatModel.model
+            },
+            // 'review' = user accepted the diff for a selection; 'auto-insert'
+            // = no selection, so the generated code was inserted directly.
+            mode: existingCode !== '' ? 'review' : 'auto-insert'
+          }
+        });
         generatedContent = extractLLMGeneratedCode(generatedContent);
         // extractLLMGeneratedCode preserves the newline that sits before
         // the closing ``` in fenced LLM output. If the user's selection
@@ -2164,6 +2234,12 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         onRequestSubmitted: (prompt: string) => {
           userPrompt = prompt;
           generatedContent = '';
+          // Reset per-generation telemetry state: the review popover survives
+          // across re-submits, so a fresh prompt must not inherit the prior
+          // run's "shown"/"errored" flags (e.g. an errored attempt followed by
+          // a successful one the user then dismisses).
+          generatedCodeShown = false;
+          streamErrored = false;
           if (existingCode !== '') {
             return;
           }
@@ -2181,8 +2257,17 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
             return;
           }
           generatedContent += content;
+          if (generatedContent !== '') {
+            generatedCodeShown = true;
+          }
         },
         onContentStreamEnd: (streamError?: string | null) => {
+          if (streamError) {
+            // Recorded before the auto-insert-only early return below so both
+            // paths see it: the review path keeps the errored diff on screen
+            // for the user to discard, which must not count as a dismissal.
+            streamErrored = true;
+          }
           if (existingCode !== '') {
             return;
           }
@@ -2206,6 +2291,9 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         },
         onUpdatedCodeChange: (content: string) => {
           generatedContent = content;
+          if (content !== '') {
+            generatedCodeShown = true;
+          }
         },
         onUpdatedCodeAccepted: () => {
           applyGeneratedCode();

--- a/src/inline-completer-telemetry.ts
+++ b/src/inline-completer-telemetry.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import type { IInlineCompleterFactory } from '@jupyterlab/completer';
+import { ITelemetryEmitter, TelemetryEventType } from './tokens';
+
+// Identifier of NBI's inline completion provider. Matches the package name and
+// NBIInlineCompletionProvider.identifier; acceptance telemetry is only emitted
+// when the accepted suggestion came from this provider.
+export const NBI_INLINE_COMPLETION_PROVIDER_ID = '@plmbr/notebook-intelligence';
+
+export interface IInlineCompletionModelInfo {
+  provider: string;
+  model: string;
+}
+
+// The inline completion provider interface has no accept callback, so the only
+// reliable signal that a suggestion was taken is the inline completer widget's
+// accept() method. Rather than subclass InlineCompleter (which would force us to
+// reproduce all of JupyterLab's factory wiring: translator, toolbar buttons,
+// keybinding hints), we wrap JupyterLab's own factory, let it build the
+// fully-wired widget, and patch just the accept() method on the instance to emit
+// acceptance telemetry for our own suggestions before delegating to the original.
+// getModelInfo is read lazily at accept time so the event reflects the model
+// configured when the suggestion was taken, not when the widget was created.
+export function wrapInlineCompleterFactory(
+  defaultFactory: IInlineCompleterFactory,
+  telemetryEmitter: ITelemetryEmitter,
+  getModelInfo: () => IInlineCompletionModelInfo
+): IInlineCompleterFactory {
+  return {
+    factory: options => {
+      const completer = defaultFactory.factory(options);
+      const originalAccept = completer.accept.bind(completer);
+      completer.accept = () => {
+        const item = completer.current;
+        if (item?.provider?.identifier === NBI_INLINE_COMPLETION_PROVIDER_ID) {
+          telemetryEmitter.emitTelemetryEvent({
+            type: TelemetryEventType.InlineCompletionAccepted,
+            data: { inlineCompletionModel: getModelInfo() }
+          });
+        }
+        originalAccept();
+      };
+      return completer;
+    }
+  };
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -144,7 +144,10 @@ export enum TelemetryEventType {
   InlineChatRequest = 'inline-chat-request',
   ChatResponse = 'chat-response',
   InlineChatResponse = 'inline-chat-response',
+  InlineChatAccepted = 'inline-chat-accepted',
+  InlineChatDismissed = 'inline-chat-dismissed',
   InlineCompletionResponse = 'inline-completion-response',
+  InlineCompletionAccepted = 'inline-completion-accepted',
   Feedback = 'feedback'
 }
 

--- a/tests/ts/inline-completer-telemetry.test.ts
+++ b/tests/ts/inline-completer-telemetry.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import {
+  wrapInlineCompleterFactory,
+  NBI_INLINE_COMPLETION_PROVIDER_ID
+} from '../../src/inline-completer-telemetry';
+import { TelemetryEventType } from '../../src/tokens';
+
+// Minimal stand-in for JupyterLab's InlineCompleter: only the surface the
+// wrapper reads (`current`) and patches (`accept`). The fake's accept() clears
+// `current` like the real widget does, which pins the load-bearing invariant
+// that the wrapper reads `current` BEFORE delegating: were the read moved after
+// originalAccept(), `current` would already be null and telemetry would silently
+// vanish, yet a fake whose accept() left `current` intact would not catch it.
+function makeCompleter(identifier?: string | null) {
+  const completer = {
+    current:
+      identifier === undefined
+        ? undefined
+        : { provider: identifier === null ? undefined : { identifier } },
+    accept: jest.fn()
+  } as any;
+  completer.accept.mockImplementation(() => {
+    completer.current = null;
+  });
+  return completer;
+}
+
+function setup(identifier?: string | null) {
+  const completer = makeCompleter(identifier);
+  const originalAccept = completer.accept;
+  const defaultFactory = { factory: jest.fn(() => completer) } as any;
+  const emitter = { emitTelemetryEvent: jest.fn() };
+  const modelInfo = { provider: 'openai-compatible', model: 'gpt-4o-mini' };
+  const wrapped = wrapInlineCompleterFactory(
+    defaultFactory,
+    emitter,
+    () => modelInfo
+  );
+  const returned = wrapped.factory({} as any);
+  return {
+    completer,
+    originalAccept,
+    defaultFactory,
+    emitter,
+    modelInfo,
+    returned
+  };
+}
+
+describe('wrapInlineCompleterFactory', () => {
+  it('delegates widget construction to the wrapped factory', () => {
+    const { defaultFactory, returned, completer } = setup(
+      NBI_INLINE_COMPLETION_PROVIDER_ID
+    );
+    expect(defaultFactory.factory).toHaveBeenCalledTimes(1);
+    // The wrapper returns the very widget the default factory built (so all of
+    // JupyterLab's toolbar/translator wiring is preserved), not a replacement.
+    expect(returned).toBe(completer);
+  });
+
+  it('emits acceptance telemetry for an NBI suggestion, then calls the original accept', () => {
+    const { completer, originalAccept, emitter, modelInfo } = setup(
+      NBI_INLINE_COMPLETION_PROVIDER_ID
+    );
+
+    completer.accept();
+
+    expect(emitter.emitTelemetryEvent).toHaveBeenCalledTimes(1);
+    expect(emitter.emitTelemetryEvent).toHaveBeenCalledWith({
+      type: TelemetryEventType.InlineCompletionAccepted,
+      data: { inlineCompletionModel: modelInfo }
+    });
+    expect(originalAccept).toHaveBeenCalledTimes(1);
+    // Telemetry must be emitted before delegating, while `current` still holds
+    // the accepted item (the fake's accept clears it).
+    expect(emitter.emitTelemetryEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      originalAccept.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('reads the model info lazily at accept time, not at widget construction', () => {
+    const completer = makeCompleter(NBI_INLINE_COMPLETION_PROVIDER_ID);
+    const defaultFactory = { factory: jest.fn(() => completer) } as any;
+    const emitter = { emitTelemetryEvent: jest.fn() };
+    const getModelInfo = jest.fn(() => ({ provider: 'p', model: 'm' }));
+
+    const wrapped = wrapInlineCompleterFactory(
+      defaultFactory,
+      emitter,
+      getModelInfo
+    );
+    wrapped.factory({} as any);
+    expect(getModelInfo).not.toHaveBeenCalled();
+
+    completer.accept();
+    expect(getModelInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit for another provider, but still calls the original accept', () => {
+    const { completer, originalAccept, emitter } = setup('some-other-provider');
+
+    completer.accept();
+
+    expect(emitter.emitTelemetryEvent).not.toHaveBeenCalled();
+    expect(originalAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit when there is no current item or provider, but still accepts', () => {
+    for (const identifier of [undefined, null] as (undefined | null)[]) {
+      const { completer, originalAccept, emitter } = setup(identifier);
+
+      completer.accept();
+
+      expect(emitter.emitTelemetryEvent).not.toHaveBeenCalled();
+      expect(originalAccept).toHaveBeenCalledTimes(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds telemetry so the two AI code-entry surfaces, auto-complete (inline completion) and cell inline chat, are tracked as distinct features with their own event identifiers. Three new `TelemetryEventType` values are introduced: `inline-completion-accepted`, `inline-chat-accepted`, and `inline-chat-dismissed`. This lets a `TelemetryListener` measure how often inline completions are accepted versus ignored, and how often inline-chat generations are applied versus dismissed, with auto-complete and inline chat cleanly separable.

## Solution
For inline completion, JupyterLab's provider interface has no accept callback, so the reliable accept signal is the inline completer widget's `accept()` method. Rather than subclass `InlineCompleter` (which would force us to reproduce JupyterLab's factory wiring: translator, toolbar buttons, keybinding hints), we wrap JupyterLab's own `IInlineCompleterFactory`, let it build the fully wired widget, and patch only `accept()` on the instance. The wrapper installs on `app.started`, which resolves after every plugin has activated (so JupyterLab's default factory is already set and ours wins as the last writer) but before layout restoration creates the per-editor completer handlers, which capture the factory once at creation and are never regenerated. `IInlineCompleterFactory` is taken as an optional dependency, so NBI still loads if JupyterLab ever stops providing it.
For inline chat, `inline-chat-accepted` fires when generated code is applied (with a `review` vs `auto-insert` mode discriminator), and `inline-chat-dismissed` fires when the popover is torn down after code was shown but never applied. An interrupted stream surfaces a marker but no usable code, so its teardown is treated as a failure rather than a dismissal.
Design note: we track acceptance reliably and derive the auto-complete ignore rate in analysis as shown (`inline-completion-response`) minus `inline-completion-accepted`, rather than emitting an explicit ignore event. An explicit-ignore heuristic would depend on JupyterLab-internal rejection signals that are fragile across versions, whereas accept-plus-derive needs only events we emit ourselves.

## Testing
`src/inline-completer-telemetry.ts` is covered by a focused unit test (delegation to the wrapped factory, provider-gated emit, read-before-delegate ordering, lazy model-info read). Full suite green: `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (376 passing), and `pytest` (1235 passing). Verified live in a running JupyterLab against a real model: `inline-completion-accepted` fires on Tab-accept with the completer toolbar UI preserved; `inline-chat-accepted` fires for both auto-insert and review-accept; `inline-chat-dismissed` fires on review-cancel and is correctly suppressed when code was applied. The inline-chat flag logic lives in the plugin command closure and is exercised by the live checks rather than unit tests.

## Risks / follow-ups
Frontend (`tokens.ts`) and backend (`api.py`) enums are kept in parity by hand; no consumer switches on the type, so adding values is backward compatible. Follow-ups noted during review, all pre-existing and out of scope here: inline-chat telemetry reports `NBIAPI.config.chatModel` even in Claude Code mode (every inline-chat event already does this, so it should be fixed holistically); the `review`/`auto-insert` mode value could become a typed union alongside the existing `editorType`/`chatMode` string discriminators.
