### PR TITLE
fix(skills): scope the GitHub import size cap to the skill subpath

### DIFF
--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -308,24 +308,40 @@ def _extract_skill(
         # GitHub tarballs wrap every entry in a single `{repo}-{sha}/` top-level directory.
         # The first member is that directory itself, so its name is our wrapper prefix.
         top_dir = members[0].name.split("/")[0]
+        # The tarball is always the whole repo, but only the skill's subtree
+        # gets installed. Scope both the size cap and the extraction to that
+        # subtree: otherwise any skill hosted in a monorepo whose *total*
+        # content exceeds the cap fails to install regardless of the skill's
+        # own size, and unrelated repo content gets written to the temp dir.
+        subtree_prefix = (
+            f"{top_dir}/{subpath}".rstrip("/") if subpath else top_dir
+        )
         safe_members = []
         for m in members:
             if m.issym() or m.islnk():
                 # Skip symlinks for safety — they can escape the extraction dir.
                 continue
             # Tar names are POSIX by spec, so use PurePosixPath to keep the
-            # absolute-path check platform-independent.
+            # absolute-path check platform-independent. Checked for every
+            # member, not just the subtree: a hostile name anywhere in the
+            # archive fails the import loudly rather than being skipped.
             path = PurePosixPath(m.name)
             if path.is_absolute() or any(p == ".." for p in path.parts):
                 raise ValueError(f"Unsafe path in archive: {m.name}")
+            if m.name != subtree_prefix and not m.name.startswith(
+                subtree_prefix + "/"
+            ):
+                continue
             if m.isfile():
                 total_bytes += m.size
                 if total_bytes > MAX_EXTRACTED_BYTES:
                     raise ValueError(
-                        "Extracted archive exceeds size limit "
+                        "Extracted skill exceeds size limit "
                         f"({MAX_EXTRACTED_BYTES // (1024 * 1024)} MB)"
                     )
             safe_members.append(m)
+        if subpath and not safe_members:
+            raise ValueError(f"Path '{subpath}' not found in repo")
         # `filter="data"` (PEP 706, available on Python 3.12+ and patch-level
         # backports of 3.10/3.11) blocks absolute paths, traversal, device
         # files, and unsafe permission bits at the tarfile layer. Our explicit

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from notebook_intelligence.skill_github_import import (
+    MAX_EXTRACTED_BYTES,
     _derive_name,
     _extract_skill,
     _fetch_tarball,
@@ -135,6 +136,83 @@ class TestExtractSkill:
             tar.addfile(info, io.BytesIO(data))
         with pytest.raises(ValueError, match="Unsafe path"):
             _extract_skill(buf.getvalue(), "", tmp_path)
+
+    def test_unsafe_path_outside_the_subtree_still_rejected(self, tmp_path):
+        """The unsafe-path check runs over every member before the subtree
+        filter: a hostile name anywhere in the archive fails the import
+        loudly even when it would never be extracted."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            skill_data = b"---\nname: foo\n---\n"
+            info = tarfile.TarInfo(name="repo-abc/skills/foo/SKILL.md")
+            info.size = len(skill_data)
+            tar.addfile(info, io.BytesIO(skill_data))
+            evil = b"evil"
+            info = tarfile.TarInfo(name="repo-abc/../escape.txt")
+            info.size = len(evil)
+            tar.addfile(info, io.BytesIO(evil))
+        with pytest.raises(ValueError, match="Unsafe path"):
+            _extract_skill(buf.getvalue(), "skills/foo", tmp_path)
+
+    def test_monorepo_sibling_content_does_not_count_against_the_cap(self, tmp_path):
+        """The size cap applies to the skill being installed, not the whole
+        repo tarball. A small skill in a large monorepo used to fail with
+        "Extracted archive exceeds size limit" because every repo file was
+        counted (the production failure reported against a skills monorepo
+        where all skills failed identically regardless of their own size)."""
+        big = "0" * (MAX_EXTRACTED_BYTES + 1)
+        tar_bytes = build_tarball({
+            "repo-abc/models/weights.bin": big,
+            "repo-abc/skills/foo/SKILL.md": "---\nname: foo\ndescription: d\n---\nb",
+        })
+        skill_root = _extract_skill(tar_bytes, "skills/foo", tmp_path)
+        assert (skill_root / "SKILL.md").exists()
+        # Non-subtree repo content is not written to the temp dir at all.
+        assert not (tmp_path / "repo-abc" / "models").exists()
+
+    def test_sibling_dir_sharing_the_subpath_prefix_is_not_confused(self, tmp_path):
+        """The subtree guard must match 'skills/foo' exactly or 'skills/foo/'
+        as a prefix, never 'skills/foobar'. A bare startswith(prefix) check
+        would both count foobar's size against foo's cap and extract foobar's
+        files alongside foo's."""
+        big = "0" * (MAX_EXTRACTED_BYTES + 1)
+        tar_bytes = build_tarball({
+            "repo-abc/skills/foobar/huge.bin": big,
+            "repo-abc/skills/foo/SKILL.md": "---\nname: foo\ndescription: d\n---\nb",
+        })
+        skill_root = _extract_skill(tar_bytes, "skills/foo", tmp_path)
+        assert (skill_root / "SKILL.md").exists()
+        assert not (tmp_path / "repo-abc" / "skills" / "foobar").exists()
+
+    def test_oversized_skill_subtree_still_rejected(self, tmp_path):
+        big = "0" * (MAX_EXTRACTED_BYTES + 1)
+        tar_bytes = build_tarball({
+            "repo-abc/skills/foo/SKILL.md": "---\nname: foo\n---\n",
+            "repo-abc/skills/foo/weights.bin": big,
+        })
+        with pytest.raises(ValueError, match="size limit"):
+            _extract_skill(tar_bytes, "skills/foo", tmp_path)
+
+    def test_subpath_pointing_at_a_file_raises_not_found(self, tmp_path):
+        # The exact-match arm of the subtree filter lets a file-valued
+        # subpath through extraction; the skill-root directory check then
+        # rejects it. Pin that it surfaces as a not-found error rather
+        # than something stranger downstream.
+        tar_bytes = build_tarball({
+            "repo-abc/skills/foo": "just a file, not a skill dir",
+        })
+        with pytest.raises(ValueError, match="not found"):
+            _extract_skill(tar_bytes, "skills/foo", tmp_path)
+
+    def test_oversized_whole_repo_skill_still_rejected(self, tmp_path):
+        # No subpath: the skill is the repo, so the cap covers everything.
+        big = "0" * (MAX_EXTRACTED_BYTES + 1)
+        tar_bytes = build_tarball({
+            "repo-abc/SKILL.md": "---\nname: foo\n---\n",
+            "repo-abc/data.bin": big,
+        })
+        with pytest.raises(ValueError, match="size limit"):
+            _extract_skill(tar_bytes, "", tmp_path)
 
     def test_skips_symlinks(self, tmp_path):
         buf = io.BytesIO()


### PR DESCRIPTION
## Summary

Installing a skill from a subpath of a large repo fails with `ValueError: Extracted archive exceeds size limit (20 MB)` even when the skill itself is tiny. `_extract_skill` counted every file in the GitHub tarball against `MAX_EXTRACTED_BYTES`, but GitHub tarballs always contain the whole repo while only the subpath subtree gets installed. In practice this means any skill hosted in a monorepo larger than 20 MB cannot be installed at all, and in a managed-skills manifest pointing at such a repo every entry fails identically on reconcile. This was hit in production with a skills monorepo where all four skills failed with the same trace through `skill_reconciler.reconcile` -> `install_managed_from_github` -> `stage_skill_from_github` -> `_extract_skill`.

## Solution

Scope both the size count and the extraction to the `{top_dir}/{subpath}` subtree. The load-bearing change is the member filter in `_extract_skill`: members outside the subtree are skipped entirely, so they neither count against the cap nor get written to the temp dir (previously the whole repo was extracted, then everything but the subtree deleted). Two related behaviors were kept deliberately:

- The unsafe-path check (absolute names, `..` segments) still runs over **every** member before the subtree filter, so a hostile name anywhere in the archive fails the import loudly rather than being silently skipped.
- When the subtree filter leaves no members for a non-empty subpath, the import raises `Path '<subpath>' not found in repo` early, before any extraction.

Side benefits: unrelated repo content is never written to disk during an import, and extraction I/O for a small skill in a large monorepo drops accordingly. The cap semantics for whole-repo skills (no subpath) are unchanged.

## Testing

- Six new regression tests in `tests/test_skill_github_import.py`: the monorepo case (large sibling content no longer trips the cap, and is not extracted), the cap still enforced on the skill subtree itself (with and without a subpath), sibling-directory prefix confusion (`skills/foobar` must not match `skills/foo`), a subpath naming a file (clean "not found"), and an unsafe path outside the subtree (still rejected).
- Full Python suite: 1312 passed. `jlpm tsc --noEmit`, `jlpm lint:check`, and `jlpm jest` green (no TypeScript changes).
- Playwright verification skipped: this is backend tar-extraction logic with no JupyterLab runtime surface; the unit tests fully pin the behavior.

## Risks / follow-ups

- The error message for an oversized skill changed from "Extracted archive exceeds size limit" to "Extracted skill exceeds size limit"; nothing in the codebase matches the old string.
- Pre-existing, out of scope: `parse_github_url` permits `.` path segments, which now surface as a "not found" error; and duplicate tar entries can raise `OSError` from `extractall` instead of a clean `ValueError` (cleanup still runs in both cases).

Reported via user support with production stack traces; no GitHub issue exists for this.