### PR TITLE
docs(readme): point blog links at nbi.plmbr.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ NBI reloads open document tabs when their files change on disk, so edits an AI a
 
 ## Configuration
 
-Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://plmbr.dev/blog/archive/support-for-any-llm-provider/).
+Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://nbi.plmbr.dev/blog/archive/support-for-any-llm-provider/).
 
 <img src="media/provider-list.png" alt="Settings dialog" width=500 />
 
@@ -430,10 +430,10 @@ c.NotebookIntelligence.enable_chat_feedback_always_visible = True
 
 ## Further reading
 
-- [Introducing Notebook Intelligence!](https://plmbr.dev/blog/archive/introducing-notebook-intelligence/)
-- [Building AI Extensions for JupyterLab](https://plmbr.dev/blog/archive/building-ai-extensions-for-jupyterlab/)
-- [Building AI Agents for JupyterLab](https://plmbr.dev/blog/archive/building-ai-agents-for-jupyterlab/)
-- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://plmbr.dev/blog/archive/support-for-any-llm-provider/)
+- [Introducing Notebook Intelligence!](https://nbi.plmbr.dev/blog/archive/introducing-notebook-intelligence/)
+- [Building AI Extensions for JupyterLab](https://nbi.plmbr.dev/blog/archive/building-ai-extensions-for-jupyterlab/)
+- [Building AI Agents for JupyterLab](https://nbi.plmbr.dev/blog/archive/building-ai-agents-for-jupyterlab/)
+- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://nbi.plmbr.dev/blog/archive/support-for-any-llm-provider/)
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

All four links in the README's Further reading section, plus the inline provider-post link in the Configuration section, pointed at `https://plmbr.dev/blog/archive/...`, which no longer exists (`plmbr.dev` no longer serves `/blog`), so every one of them 404ed.

## Solution

The blog lives on the project site subdomain. Point all five links at `https://nbi.plmbr.dev/blog/archive/<slug>/`, same slugs, new host.

## Testing

Every rewritten URL verified live with an HTTP 200. Docs-only change, so no automated tests apply; `jlpm lint:check` passes.

Fixes #395
