### PR TITLE
fix(chat): require only one Enter to submit after Korean IME composition

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3349,6 +3349,11 @@ function SidebarComponent(props: any) {
 
   const onPromptKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
+      // Skip the Enter that finalizes an IME composition (e.g. Korean
+      // hangul), which fires with key === 'Enter' but should not submit.
+      if (event.nativeEvent.isComposing || event.keyCode === 229) {
+        return;
+      }
       event.stopPropagation();
       event.preventDefault();
       if (showPopover) {
@@ -5020,6 +5025,11 @@ function InlinePromptComponent(props: any) {
     event.stopPropagation();
 
     if (event.key === 'Enter' && !event.shiftKey) {
+      // Skip the Enter that finalizes an IME composition (e.g. Korean
+      // hangul), which fires with key === 'Enter' but should not submit.
+      if (event.nativeEvent.isComposing || event.keyCode === 229) {
+        return;
+      }
       event.preventDefault();
       if (inputSubmitted && (event.metaKey || event.ctrlKey)) {
         props.onUpdatedCodeAccepted();


### PR DESCRIPTION
## Summary
- Enter finalizing an IME composition (Korean/Japanese/Chinese) was also treated as the chat submit trigger, forcing users to press Enter twice to actually send a message.
- Skip that composition-finalizing Enter (`isComposing === true` or `keyCode === 229`) in both the sidebar chat input and inline prompt input.

## Test plan
- [ ] Type Korean text via IME in the chat sidebar input, press Enter to confirm composition, then press Enter again to submit — verify one Enter now submits normally without cutting off text.
- [ ] Verify inline prompt input behaves the same way.
- [ ] Verify English/non-IME input still submits on a single Enter.