### PR TITLE
fix(chat): stop inline-code CSS from leaking into fenced code blocks

### DIFF
--- a/src/markdown-code-class.ts
+++ b/src/markdown-code-class.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Kept dependency-free (no React/react-markdown imports) so it can be unit
+// tested directly under Jest: markdown-renderer.tsx imports react-markdown
+// at module scope, which ships ESM `export` syntax that jest.config.js's
+// default (no `transformIgnorePatterns` override) can't parse — anything
+// importing markdown-renderer.tsx transitively fails at parse time before a
+// test can run (see the reverted MarkdownRenderer tests from PR #385).
+
+// react-markdown@9 never sets `inline` (removed upstream), so the `code`
+// component's `if (inline || !match)` branch also catches a fenced block
+// with an unrecognized/missing language — that case keeps its default
+// `pre > code` nesting from remark-rehype, unlike the SyntaxHighlighter
+// branch, so it shouldn't get inline-code styling either. Distinguish the
+// two by content shape instead: remark-rehype always appends a trailing
+// `\n` to fenced code (even single-line), while true inline code never
+// contains one. Only genuine inline code gets `.inline-code`, so CSS can
+// target it directly instead of via `:not(pre) > code`, which broke once
+// `PreTag="div"` put a wrapper div between a highlighted block's `<code>`
+// and the outer `<pre>`.
+export function resolveCodeClassName(
+  children: unknown,
+  className?: string
+): string | undefined {
+  const isTrulyInline = !String(children).includes('\n');
+  return isTrulyInline ? `inline-code ${className || ''}`.trim() : className;
+}

--- a/src/markdown-renderer.tsx
+++ b/src/markdown-renderer.tsx
@@ -17,6 +17,7 @@ import { PathExt } from '@jupyterlab/coreutils';
 import { MarkdownLink } from './components/markdown-link';
 import { isDarkTheme, writeTextToClipboard } from './utils';
 import { IActiveDocumentInfo } from './tokens';
+import { resolveCodeClassName } from './markdown-code-class';
 
 type MarkdownRendererProps = {
   children: string;
@@ -104,7 +105,10 @@ export function MarkdownRenderer({
 
           if (inline || !match) {
             return (
-              <code className={className} {...props}>
+              <code
+                className={resolveCodeClassName(children, className)}
+                {...props}
+              >
                 {children}
               </code>
             );

--- a/style/base.css
+++ b/style/base.css
@@ -729,7 +729,7 @@ pre:has(.code-block-header) {
   font-size: 13px;
 }
 
-.chat-message-content :not(pre) > code {
+.chat-message-content code.inline-code {
   background-color: var(--jp-layout-color2);
   padding: 1px 4px;
   border-radius: 3px;
@@ -1794,7 +1794,7 @@ button.send-button:disabled:active:not(.send-button-stop) {
 
 /* Inline code also fills with --jp-layout-color2, which now matches this box's
    fill; recess nested code to --jp-layout-color1 so it stays distinct. */
-.expandable-content-text :not(pre) > code {
+.expandable-content-text code.inline-code {
   background-color: var(--jp-layout-color1);
 }
 

--- a/tests/ts/markdown-code-class.test.ts
+++ b/tests/ts/markdown-code-class.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { resolveCodeClassName } from '../../src/markdown-code-class';
+
+describe('resolveCodeClassName', () => {
+  it('marks single-line content (true inline code) with inline-code', () => {
+    expect(resolveCodeClassName('inline_var')).toBe('inline-code');
+  });
+
+  it('preserves an existing className alongside inline-code', () => {
+    expect(resolveCodeClassName('inline_var', 'some-class')).toBe(
+      'inline-code some-class'
+    );
+  });
+
+  it('does not mark multi-line content (a highlighted fenced block)', () => {
+    expect(
+      resolveCodeClassName('import json\nimport logging\n', 'language-python')
+    ).toBe('language-python');
+  });
+
+  it('does not mark multi-line content with no language class (unmatched fence)', () => {
+    expect(resolveCodeClassName('plain text block\n')).toBeUndefined();
+  });
+
+  it('does not mark a single-line fenced block that still carries a trailing newline', () => {
+    expect(resolveCodeClassName('x\n', 'language-text')).toBe('language-text');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #401

- `style/base.css`'s `:not(pre) > code` selector (two occurrences) assumed a fenced code block's `<code>` is always the *direct* child of a real `<pre>`. That breaks for syntax-highlighted blocks: `markdown-renderer.tsx`'s `SyntaxHighlighter` uses `PreTag="div"`, so a highlighted block's `<code>` sits under a wrapper `<div>`, not directly under the outer `<pre>` (which still exists further up, from `remark-rehype`'s default wrapping — only `code` is overridden, not `pre`).
- The selector misfired and applied inline-code `padding: 1px 4px` to highlighted blocks too. Since `<code>` is a CSS inline element spanning multiple lines via literal `\n` + `white-space: pre`, left padding on a wrapped inline box only paints on the **first line fragment** per the CSS box model — visible as a first-line-only indent, invisible in copied text (pure paint, not a text/DOM content difference — confirmed via direct DOM inspection and copy/paste testing).
- Fix: replace the parent-structure guess with an explicit `.inline-code` class assigned in JS (`src/markdown-code-class.ts`, new — kept dependency-free so it's unit-testable, see Test plan). `react-markdown@9` no longer passes an `inline` prop (removed upstream, so the existing `if (inline || !match)` branch was already relying on `!match` alone), so the reliable signal is content shape: `remark-rehype` always appends a trailing `\n` to fenced code (even single-line), while true inline code never contains one.

See #401 for the full root-cause writeup, screenshot, and reproduction.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Full Jest suite — 31 suites / 381 tests passing, no regressions
- [x] 5 new unit tests for `resolveCodeClassName` (`tests/ts/markdown-code-class.test.ts`) covering: true inline code, inline code with an existing className, a highlighted fenced block, a fenced block with no/unrecognized language (multi- and single-line)
- [x] Synthetic jsdom test running the actual old (`:not(pre) > code`) vs. new (`code.inline-code`) selector text against the real captured DOM shape from the live app — confirms `padding-left: 4px` fires on the old selector for a highlighted block (the bug, reproduced exactly) and not on the new one
- [ ] Manual verification in a running JupyterLab chat panel (not done — no way to launch the dev UI in this environment; #401 has the live screenshot this fix addresses)

Note: a direct Jest-level render test of `<MarkdownRenderer>` itself isn't feasible under the current `jest.config.js` (no `transformIgnorePatterns` override, so importing `react-markdown`'s ESM `export` syntax fails at parse time) — same constraint hit and accepted in #385's work. `resolveCodeClassName` was extracted into its own dependency-free module specifically to get real unit coverage despite that constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)