### PR TITLE
fix(claude): forward inline edit system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 ### Fixed
 
-- **Claude inline edits now receive their intended system instructions and applicable workspace rules.** The inline-edit prompt is forwarded through the Claude handler to Anthropic's `system` field instead of being silently dropped before generation.
+- **Claude inline edits now receive their intended system instructions and applicable workspace rules.** The inline-edit prompt is forwarded through the Claude handler to Anthropic's `system` field instead of being silently dropped before generation. Injected repository guidance is capped against the model context window, and disabling rules now suppresses `AGENTS.md` instructions as well as configured rule files.
 - **Session history follows `CLAUDE_CONFIG_DIR`** (#373). The chat-sidebar resume picker and the launcher tile's session list always read transcripts from `~/.claude/projects`, so both came up empty when the Claude CLI was configured with `CLAUDE_CONFIG_DIR` and wrote its transcripts elsewhere. The session listing now resolves the CLI's config dir the same way the skills and spinner-verbs paths already did.
 - **User-scope MCP config and the plugin cache follow `CLAUDE_CONFIG_DIR`** (#375). The MCP management tab read user-scope servers from `~/.claude.json` even though the CLI relocates that file to `$CLAUDE_CONFIG_DIR/.claude.json` when the override is set (so reads and CLI-mediated writes diverged), and the Plugins panel's cache fallback pointed at `~/.claude/plugins` instead of the relocated cache. Both now resolve the CLI's actual locations; `CLAUDE_CODE_PLUGIN_CACHE_DIR` still wins for the plugin cache when set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 ### Fixed
 
+- **Claude inline edits now receive their intended system instructions and applicable workspace rules.** The inline-edit prompt is forwarded through the Claude handler to Anthropic's `system` field instead of being silently dropped before generation.
 - **Session history follows `CLAUDE_CONFIG_DIR`** (#373). The chat-sidebar resume picker and the launcher tile's session list always read transcripts from `~/.claude/projects`, so both came up empty when the Claude CLI was configured with `CLAUDE_CONFIG_DIR` and wrote its transcripts elsewhere. The session listing now resolves the CLI's config dir the same way the skills and spinner-verbs paths already did.
 - **User-scope MCP config and the plugin cache follow `CLAUDE_CONFIG_DIR`** (#375). The MCP management tab read user-scope servers from `~/.claude.json` even though the CLI relocates that file to `$CLAUDE_CONFIG_DIR/.claude.json` when the override is set (so reads and CLI-mediated writes diverged), and the Plugins panel's cache fallback pointed at `~/.claude/plugins` instead of the relocated cache. Both now resolve the CLI's actual locations; `CLAUDE_CODE_PLUGIN_CACHE_DIR` still wins for the plugin cache when set.
 

--- a/notebook_intelligence/base_chat_participant.py
+++ b/notebook_intelligence/base_chat_participant.py
@@ -432,9 +432,18 @@ class BaseChatParticipant(ChatParticipant):
     def chat_prompt(self, model_provider: str, model_name: str) -> str:
         return Prompts.generic_chat_prompt(model_provider, model_name)
     
-    def _inject_rules_into_system_prompt(self, base_prompt: str, request: ChatRequest) -> str:
+    def _inject_rules_into_system_prompt(
+        self,
+        base_prompt: str,
+        request: ChatRequest,
+        max_tokens: int = None,
+    ) -> str:
         """Inject applicable rules into system prompt based on request context."""
-        return self._rule_injector.inject_rules(base_prompt, request)
+        if max_tokens is None:
+            return self._rule_injector.inject_rules(base_prompt, request)
+        return self._rule_injector.inject_rules(
+            base_prompt, request, max_tokens=max_tokens
+        )
 
     async def generate_code_cell(self, request: ChatRequest) -> str:
         chat_model = request.host.chat_model

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -894,11 +894,15 @@ class ClaudeChatModel(ChatModel):
             response.finish()
             return
         try:
-            with self._client.messages.stream(
-                model=self._model_id,
-                max_tokens=10000,
-                messages=messages
-            ) as stream:
+            stream_options: dict[str, Any] = {
+                "model": self._model_id,
+                "max_tokens": 10000,
+                "messages": messages,
+            }
+            system_prompt = options.get("system_prompt")
+            if system_prompt:
+                stream_options["system"] = system_prompt
+            with self._client.messages.stream(**stream_options) as stream:
                 for chunk in stream.text_stream:
                     if cancel_token is not None and cancel_token.is_cancel_requested:
                         break
@@ -2214,7 +2218,22 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
                 claude_settings.get('base_url', None)
             )
             messages = request.chat_history.copy()
-            chat_model.completions(messages, response=response, cancel_token=request.cancel_token)
+            completion_options = options.copy()
+            base_system_prompt = completion_options.get("system_prompt", "")
+            system_prompt = self._inject_rules_into_system_prompt(
+                base_system_prompt,
+                request,
+            )
+            if system_prompt:
+                completion_options["system_prompt"] = system_prompt
+            else:
+                completion_options.pop("system_prompt", None)
+            chat_model.completions(
+                messages,
+                response=response,
+                cancel_token=request.cancel_token,
+                options=completion_options,
+            )
         except Exception as e:
             log.error(f"Error while handling chat request!\n{e}")
             response.stream(MarkdownData(f"Oops! There was a problem handling chat request. Please try again with a different prompt."))

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -2220,9 +2220,14 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
             messages = request.chat_history.copy()
             completion_options = options.copy()
             base_system_prompt = completion_options.get("system_prompt", "")
+            system_prompt_token_budget = completion_options.pop(
+                "system_prompt_token_budget",
+                None,
+            )
             system_prompt = self._inject_rules_into_system_prompt(
                 base_system_prompt,
                 request,
+                max_tokens=system_prompt_token_budget,
             )
             if system_prompt:
                 completion_options["system_prompt"] = system_prompt

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -110,6 +110,25 @@ def _truncate_context_content(content: str, token_budget: int) -> str:
     return truncated + "\n...[truncated]"
 
 
+def _inline_system_prompt_token_budget(
+    manager,
+    chat_history: list[dict],
+    base_system_prompt: str,
+) -> int:
+    """Reserve at most 80% of context for inline history plus system text."""
+    context_budget = int(0.8 * _resolve_context_token_limit(manager))
+    history_tokens = sum(
+        _token_count(message.get("content", ""))
+        for message in chat_history
+        if isinstance(message, dict)
+        and isinstance(message.get("content", ""), str)
+    )
+    # The base code-generation instruction is essential even when the supplied
+    # code context already exceeds the target budget. In that case rules are
+    # omitted rather than trimming the behavioral contract itself.
+    return max(_token_count(base_system_prompt), context_budget - history_tokens)
+
+
 def _build_additional_context_message(
     file_path: str,
     context_filename: str,
@@ -3096,7 +3115,17 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                 language,
                 modifying_existing_code=existing_code != '',
             )
-            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=prompt, language=language, kernel_name=kernel_name, chat_history=self.chat_history.get_history(chatId), cancel_token=cancel_token, rule_context=rule_context), response_emitter, options={"system_prompt": system_prompt})
+            request_history = self.chat_history.get_history(chatId)
+            completion_options = {"system_prompt": system_prompt}
+            if is_claude_code_mode:
+                completion_options["system_prompt_token_budget"] = (
+                    _inline_system_prompt_token_budget(
+                        ai_service_manager,
+                        request_history,
+                        system_prompt,
+                    )
+                )
+            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=prompt, language=language, kernel_name=kernel_name, chat_history=request_history, cancel_token=cancel_token, rule_context=rule_context), response_emitter, options=completion_options)
             thread = threading.Thread(target=self._run_request_thread, args=(coro, messageId, response_emitter))
             thread.start()
         elif messageType == RequestDataType.InlineCompletionRequest:

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -73,6 +73,7 @@ from notebook_intelligence.claude import (
 )
 from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
 from notebook_intelligence.plugin_manager import PluginManager
+from notebook_intelligence.prompts import Prompts
 from notebook_intelligence.tour_config import load_tour_config
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
@@ -3081,8 +3082,6 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
             response_emitter = WebsocketCopilotResponseEmitter(chatId, messageId, self, self.chat_history)
             cancel_token = CancelTokenImpl()
             self._messageCallbackHandlers[messageId] = MessageCallbackHandlers(response_emitter, cancel_token)
-            existing_code_message = " Update the existing code section and return a modified version. Don't just return the update, recreate the existing code section with the update." if existing_code != '' else ''
-            
             # Create rule context for rule evaluation
             # Note: Using 'inline-chat' mode for rule matching even though chat_mode is 'ask' for handler compatibility
             rule_context = self._context_factory.create(
@@ -3093,7 +3092,11 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                 root_dir=NotebookIntelligence.root_dir
             )
             
-            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=prompt, language=language, kernel_name=kernel_name, chat_history=self.chat_history.get_history(chatId), cancel_token=cancel_token, rule_context=rule_context), response_emitter, options={"system_prompt": f"You are an assistant that generates code for '{language}' language. You generate code between existing leading and trailing code sections.{existing_code_message} Be concise and return only code as a response. Don't include leading content or trailing content in your response, they are provided only for context. You can reuse methods and symbols defined in leading and trailing content."})
+            system_prompt = Prompts.inline_chat_system_prompt(
+                language,
+                modifying_existing_code=existing_code != '',
+            )
+            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=prompt, language=language, kernel_name=kernel_name, chat_history=self.chat_history.get_history(chatId), cancel_token=cancel_token, rule_context=rule_context), response_emitter, options={"system_prompt": system_prompt})
             thread = threading.Thread(target=self._run_request_thread, args=(coro, messageId, response_emitter))
             thread.start()
         elif messageType == RequestDataType.InlineCompletionRequest:

--- a/notebook_intelligence/prompts.py
+++ b/notebook_intelligence/prompts.py
@@ -38,6 +38,11 @@ The active document is the source code the user is looking at right now.
 You can only give one reply for each conversation turn.
 """
 
+INLINE_CHAT_SYSTEM_PROMPT = """You are an assistant that generates code for '{language}' language. You generate code between existing leading and trailing code sections.{existing_code_instruction} Be concise and return only code as a response. Don't include leading content or trailing content in your response, they are provided only for context. You can reuse methods and symbols defined in leading and trailing content."""
+
+INLINE_CHAT_EXISTING_CODE_INSTRUCTION = " Update the existing code section and return a modified version. Don't just return the update, recreate the existing code section with the update."
+
+
 class Prompts:
     @staticmethod
     def generic_chat_prompt(model_provider: str, model_name: str) -> str:
@@ -46,3 +51,18 @@ class Prompts:
     @staticmethod
     def github_copilot_chat_prompt(model_provider: str, model_name: str) -> str:
         return CHAT_SYSTEM_PROMPT.format(AI_ASSISTANT_NAME="GitHub Copilot", IDE_NAME=IDE_NAME, OS_TYPE=OS_TYPE, MODEL_NAME=model_name, MODEL_PROVIDER=model_provider)
+
+    @staticmethod
+    def inline_chat_system_prompt(
+        language: str,
+        modifying_existing_code: bool = False,
+    ) -> str:
+        existing_code_instruction = (
+            INLINE_CHAT_EXISTING_CODE_INSTRUCTION
+            if modifying_existing_code
+            else ""
+        )
+        return INLINE_CHAT_SYSTEM_PROMPT.format(
+            language=language,
+            existing_code_instruction=existing_code_instruction,
+        )

--- a/notebook_intelligence/rule_injector.py
+++ b/notebook_intelligence/rule_injector.py
@@ -3,11 +3,15 @@
 import logging
 from pathlib import Path
 
+import tiktoken
+
 from notebook_intelligence.api import ChatRequest
 from notebook_intelligence.rule_manager import RuleManager
 from notebook_intelligence.util import get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
+_TOKEN_ENCODING = tiktoken.encoding_for_model("gpt-4o")
+_TRUNCATION_MARKER = "\n...[additional guidelines truncated]"
 
 
 class RuleInjector:
@@ -28,8 +32,16 @@ class RuleInjector:
             log.warning(f"Failed to read AGENTS.md from {agents_path}: {e}")
             return ''
     
-    def inject_rules(self, base_prompt: str, request: ChatRequest) -> str:
+    def inject_rules(
+        self,
+        base_prompt: str,
+        request: ChatRequest,
+        max_tokens: int = None,
+    ) -> str:
         """Inject applicable rules into system prompt based on request context."""
+        if not request.host.nbi_config.rules_enabled:
+            return base_prompt
+
         sections = []
 
         agents_md = self._read_agents_md()
@@ -38,7 +50,7 @@ class RuleInjector:
 
         if request.rule_context:
             rule_manager: RuleManager = request.host.get_rule_manager()
-            if rule_manager and request.host.nbi_config.rules_enabled:
+            if rule_manager:
                 applicable_rules = rule_manager.get_applicable_rules(request.rule_context)
                 if applicable_rules:
                     formatted_rules = rule_manager.format_rules_for_llm(applicable_rules)
@@ -47,4 +59,22 @@ class RuleInjector:
         if not sections:
             return base_prompt
 
-        return f"{base_prompt}\n\n# Additional Guidelines\n" + "\n\n".join(sections)
+        guidelines = "# Additional Guidelines\n" + "\n\n".join(sections)
+        separator = "\n\n" if base_prompt else ""
+        if max_tokens is not None:
+            base_tokens = len(_TOKEN_ENCODING.encode(base_prompt + separator))
+            guideline_budget = max_tokens - base_tokens
+            if guideline_budget <= 0:
+                return base_prompt
+            encoded_guidelines = _TOKEN_ENCODING.encode(guidelines)
+            if len(encoded_guidelines) > guideline_budget:
+                marker_tokens = _TOKEN_ENCODING.encode(_TRUNCATION_MARKER)
+                content_budget = guideline_budget - len(marker_tokens)
+                if content_budget <= 0:
+                    return base_prompt
+                guidelines = (
+                    _TOKEN_ENCODING.decode(encoded_guidelines[:content_budget]).rstrip()
+                    + _TRUNCATION_MARKER
+                )
+
+        return base_prompt + separator + guidelines

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -915,6 +915,50 @@ class TestHandleChatRequestErrorHandling:
         response.finish.assert_not_called()
         response.stream.assert_not_called()
 
+    def test_inline_chat_forwards_rule_enhanced_system_prompt(self, monkeypatch):
+        participant = _make_participant()
+        participant._rule_injector.inject_rules.return_value = (
+            "inline edit prompt\n\nworkspace rule"
+        )
+        request = _make_chat_request("inline-chat")
+        request.host.nbi_config.claude_settings = {
+            "chat_model": "claude-sonnet-test",
+            "api_key": "test-key",
+            "base_url": "https://example.test",
+        }
+        request.chat_history = [{"role": "user", "content": "change this"}]
+        request.cancel_token = MagicMock()
+        response = Mock(spec=ChatResponse)
+        chat_model = MagicMock()
+        monkeypatch.setattr(
+            claude_module,
+            "ClaudeChatModel",
+            MagicMock(return_value=chat_model),
+        )
+        options = {"system_prompt": "inline edit prompt", "other": "value"}
+
+        asyncio.run(
+            participant.handle_inline_chat_request(request, response, options)
+        )
+
+        participant._rule_injector.inject_rules.assert_called_once_with(
+            "inline edit prompt",
+            request,
+        )
+        chat_model.completions.assert_called_once_with(
+            request.chat_history,
+            response=response,
+            cancel_token=request.cancel_token,
+            options={
+                "system_prompt": "inline edit prompt\n\nworkspace rule",
+                "other": "value",
+            },
+        )
+        assert options == {
+            "system_prompt": "inline edit prompt",
+            "other": "value",
+        }
+
 
 class _FakeMessageStream:
     """Stand-in for the Anthropic SDK's MessageStreamManager.
@@ -991,7 +1035,21 @@ class TestClaudeChatModelStreaming:
         assert kwargs["model"] == "claude-sonnet-test"
         assert kwargs["messages"] == [{"role": "user", "content": "x"}]
         assert kwargs["max_tokens"] == 10000
+        assert "system" not in kwargs
         model._client.messages.create.assert_not_called()
+
+    def test_system_prompt_is_forwarded_to_anthropic_stream(self):
+        model, _ = _make_chat_model(["updated code"])
+        response = MagicMock()
+
+        model.completions(
+            messages=[{"role": "user", "content": "change this"}],
+            response=response,
+            options={"system_prompt": "return only replacement code"},
+        )
+
+        kwargs = model._client.messages.stream.call_args.kwargs
+        assert kwargs["system"] == "return only replacement code"
 
     def test_empty_chunks_are_skipped(self):
         # The Anthropic stream can occasionally yield empty strings between

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -959,6 +959,42 @@ class TestHandleChatRequestErrorHandling:
             "other": "value",
         }
 
+    def test_inline_chat_applies_system_prompt_token_budget(self, monkeypatch):
+        participant = _make_participant()
+        participant._rule_injector.inject_rules.return_value = "bounded prompt"
+        request = _make_chat_request("inline-chat")
+        request.host.nbi_config.claude_settings = {
+            "chat_model": "claude-sonnet-test",
+        }
+        request.chat_history = [{"role": "user", "content": "change this"}]
+        request.cancel_token = MagicMock()
+        response = Mock(spec=ChatResponse)
+        chat_model = MagicMock()
+        monkeypatch.setattr(
+            claude_module,
+            "ClaudeChatModel",
+            MagicMock(return_value=chat_model),
+        )
+
+        asyncio.run(
+            participant.handle_inline_chat_request(
+                request,
+                response,
+                {
+                    "system_prompt": "inline edit prompt",
+                    "system_prompt_token_budget": 500,
+                },
+            )
+        )
+
+        participant._rule_injector.inject_rules.assert_called_once_with(
+            "inline edit prompt",
+            request,
+            max_tokens=500,
+        )
+        completion_options = chat_model.completions.call_args.kwargs["options"]
+        assert completion_options == {"system_prompt": "bounded prompt"}
+
 
 class _FakeMessageStream:
     """Stand-in for the Anthropic SDK's MessageStreamManager.

--- a/tests/test_rule_injector.py
+++ b/tests/test_rule_injector.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 from notebook_intelligence.api import ChatRequest
-from notebook_intelligence.rule_injector import RuleInjector
+from notebook_intelligence.rule_injector import RuleInjector, _TOKEN_ENCODING
 from notebook_intelligence.ruleset import Rule, RuleContext
 
 
@@ -102,8 +102,42 @@ class TestRuleInjector:
         base_prompt = ""
         result = injector.inject_rules(base_prompt, request)
         
-        expected = "\n\n# Additional Guidelines\n# Test Rules\n- Be helpful"
+        expected = "# Additional Guidelines\n# Test Rules\n- Be helpful"
         assert result == expected
+
+    def test_disabled_rules_also_suppress_agents_md(self, tmp_path):
+        injector = RuleInjector()
+        request = Mock(spec=ChatRequest)
+        request.rule_context = None
+        request.host.nbi_config.rules_enabled = False
+        (tmp_path / "AGENTS.md").write_text(
+            "# Repo Rules\n- Keep notebooks tidy\n",
+            encoding="utf-8",
+        )
+
+        with patch(
+            "notebook_intelligence.rule_injector.get_jupyter_root_dir",
+            return_value=str(tmp_path),
+        ):
+            result = injector.inject_rules("BASE", request)
+
+        assert result == "BASE"
+
+    def test_token_budget_truncates_additional_guidelines(self):
+        injector = RuleInjector()
+        request = Mock(spec=ChatRequest)
+        request.rule_context = Mock(spec=RuleContext)
+        request.host.nbi_config.rules_enabled = True
+        rule_manager = Mock()
+        rule_manager.get_applicable_rules.return_value = [Mock(spec=Rule)]
+        rule_manager.format_rules_for_llm.return_value = "rule " * 1_000
+        request.host.get_rule_manager.return_value = rule_manager
+
+        result = injector.inject_rules("BASE", request, max_tokens=30)
+
+        assert result.startswith("BASE\n\n# Additional Guidelines")
+        assert result.endswith("...[additional guidelines truncated]")
+        assert len(_TOKEN_ENCODING.encode(result)) <= 30
 
     def test_inject_rules_with_agents_md_only(self, tmp_path):
         injector = RuleInjector()

--- a/tests/test_websocket_handler_integration.py
+++ b/tests/test_websocket_handler_integration.py
@@ -1,11 +1,17 @@
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 import json
 from unittest.mock import Mock, patch, MagicMock
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application
 from notebook_intelligence.extension import WebsocketCopilotHandler
+from notebook_intelligence.api import ChatResponse
+from notebook_intelligence.claude import ClaudeCodeChatParticipant
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.prompts import Prompts
+from notebook_intelligence.rule_injector import RuleInjector
 from notebook_intelligence.ruleset import RuleContext
 
 
@@ -176,9 +182,114 @@ class TestWebsocketHandlerIntegration:
         assert chat_request.kernel_name == 'python3'
 
         options = mock_ai_manager.handle_chat_request.call_args.kwargs['options']
-        assert options['system_prompt'] == Prompts.inline_chat_system_prompt(
-            'python'
+        assert options['system_prompt'] == (
+            "You are an assistant that generates code for 'python' language. "
+            "You generate code between existing leading and trailing code "
+            "sections. Be concise and return only code as a response. Don't "
+            "include leading content or trailing content in your response, "
+            "they are provided only for context. You can reuse methods and "
+            "symbols defined in leading and trailing content."
         )
+        assert options["system_prompt_token_budget"] > 0
+
+    def test_generate_code_existing_edit_reaches_anthropic_system_prompt(self):
+        """Exercise handler -> Claude participant -> Anthropic SDK wiring."""
+        manager = MagicMock()
+        manager.is_claude_code_mode = True
+        manager.nbi_config = SimpleNamespace(
+            claude_settings={
+                "chat_model": "claude-sonnet-test",
+                "api_key": "test-key",
+                "base_url": "https://example.test",
+            },
+            rules_enabled=False,
+        )
+        participant = ClaudeCodeChatParticipant.__new__(
+            ClaudeCodeChatParticipant
+        )
+        participant._rule_injector = RuleInjector()
+        sdk_client = MagicMock()
+
+        class Stream:
+            text_stream = iter(["updated = True"])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        sdk_client.messages.stream.return_value = Stream()
+
+        async def dispatch(request, response, options=None):
+            request.host = manager
+            await participant.handle_chat_request(
+                request,
+                response,
+                options or {},
+            )
+
+        manager.handle_chat_request = dispatch
+        response = MagicMock(spec=ChatResponse)
+        context_factory = MagicMock(spec=RuleContextFactory)
+        context_factory.create.return_value = MagicMock(spec=RuleContext)
+
+        message = {
+            "id": "inline-existing",
+            "type": "generate-code",
+            "data": {
+                "chatId": "inline-chat",
+                "prompt": "set the flag",
+                "prefix": "before = True",
+                "suffix": "after = True",
+                "existingCode": "updated = False",
+                "language": "python",
+                "kernelName": "python3",
+                "filename": "script.py",
+            },
+        }
+
+        with patch(
+            "notebook_intelligence.extension.ai_service_manager",
+            manager,
+        ), patch(
+            "notebook_intelligence.extension.NotebookIntelligence.root_dir",
+            "/workspace",
+        ), patch(
+            "notebook_intelligence.extension.threading.Thread"
+        ) as thread_cls, patch(
+            "notebook_intelligence.extension.WebsocketCopilotResponseEmitter",
+            return_value=response,
+        ), patch(
+            "notebook_intelligence.claude._create_anthropic_client",
+            return_value=sdk_client,
+        ), patch(
+            "notebook_intelligence.extension.ThreadSafeWebSocketConnector"
+        ):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=context_factory,
+            )
+            handler.on_message(json.dumps(message))
+            request_coro = thread_cls.call_args.kwargs["args"][0]
+            asyncio.run(request_coro)
+
+        stream_options = sdk_client.messages.stream.call_args.kwargs
+        assert stream_options["system"] == (
+            "You are an assistant that generates code for 'python' language. "
+            "You generate code between existing leading and trailing code "
+            "sections. Update the existing code section and return a modified "
+            "version. Don't just return the update, recreate the existing code "
+            "section with the update. Be concise and return only code as a "
+            "response. Don't include leading content or trailing content in "
+            "your response, they are provided only for context. You can reuse "
+            "methods and symbols defined in leading and trailing content."
+        )
+        assert stream_options["messages"][-1] == {
+            "role": "user",
+            "content": "Generate code for: set the flag",
+        }
     
     @patch('notebook_intelligence.extension.ai_service_manager')
     @patch('notebook_intelligence.extension.NotebookIntelligence')

--- a/tests/test_websocket_handler_integration.py
+++ b/tests/test_websocket_handler_integration.py
@@ -5,6 +5,7 @@ from tornado.httputil import HTTPServerRequest
 from tornado.web import Application
 from notebook_intelligence.extension import WebsocketCopilotHandler
 from notebook_intelligence.context_factory import RuleContextFactory
+from notebook_intelligence.prompts import Prompts
 from notebook_intelligence.ruleset import RuleContext
 
 
@@ -173,6 +174,11 @@ class TestWebsocketHandlerIntegration:
         chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
         assert chat_request.language == 'python'
         assert chat_request.kernel_name == 'python3'
+
+        options = mock_ai_manager.handle_chat_request.call_args.kwargs['options']
+        assert options['system_prompt'] == Prompts.inline_chat_system_prompt(
+            'python'
+        )
     
     @patch('notebook_intelligence.extension.ai_service_manager')
     @patch('notebook_intelligence.extension.NotebookIntelligence')


### PR DESCRIPTION
## Summary

- forward Claude inline-edit instructions through the participant to Anthropic's `system` field
- inject applicable workspace rules into inline-edit prompts
- cap injected guidance against the remaining inline context budget
- make `rules_enabled=false` suppress `AGENTS.md` as well as configured rules
- avoid leading whitespace when rules are injected without a base prompt
- centralize prompt construction and add handler-to-Anthropic regression coverage for both inline prompt branches

## Validation

- `.venv/bin/python -m pytest -q tests/test_rule_injector.py tests/test_base_chat_participant_integration.py tests/test_claude_client.py tests/test_websocket_handler_integration.py` (113 passed)
- `.venv/bin/python -m pytest -q` (1,443 passed; one subprocess teardown warning)
