### PR TITLE
fix(chat): budget ask-mode history by tokens

### DIFF
--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -598,12 +598,18 @@ class AIServiceManager(Host):
             return
         response.participant_id = prompt_parts.participant
 
-        # add MCP server prompt messages to chat history
+        # Add MCP server prompt messages to chat history. Record their count
+        # so ask-mode budgeting can distinguish this current-request prompt
+        # sequence from prior conversation and keep its roles atomic.
+        request.mcp_prompt_message_count = 0
         if prompt_parts.mcp_prompt_name != "":
             mcp_server_prompt_messages = request.host.get_mcp_server_prompt_value(prompt_parts.mcp_server_name, prompt_parts.mcp_prompt_name, prompt_parts.mcp_arguments)
             if mcp_server_prompt_messages is not None:
                 for message in mcp_server_prompt_messages:
                     request.chat_history.append(message)
+                request.mcp_prompt_message_count = len(
+                    mcp_server_prompt_messages
+                )
             request.chat_history.append({"role": "user", "content": prompt_parts.input})
         else:
             request.chat_history.append({"role": "user", "content": prompt_parts.input})

--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -191,6 +191,10 @@ class ChatRequest:
     # Claude-mode permission mode, already clamped server-side against the
     # bypass policy and managed settings at the websocket boundary.
     permission_mode: str = 'default'
+    # These budgeting hints are appended to preserve the positional indexes
+    # of the existing public ChatRequest fields.
+    mcp_prompt_message_count: int = 0
+    required_context_message_count: int = 0
 
 @dataclass
 class ResponseStreamData:
@@ -1055,6 +1059,11 @@ class AIModel(LLMPropertyProvider):
     @property
     def context_window(self) -> int:
         raise NotImplementedError
+
+    @property
+    def context_window_is_configured(self) -> bool:
+        """Whether context_window is authoritative enough for pruning."""
+        return True
 
     @property
     def supports_tools(self) -> bool:

--- a/notebook_intelligence/base_chat_participant.py
+++ b/notebook_intelligence/base_chat_participant.py
@@ -8,11 +8,33 @@ from notebook_intelligence.prompts import Prompts
 import base64
 import logging
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
+from notebook_intelligence.chat_history_budget import budget_chat_messages
 from notebook_intelligence.rule_injector import RuleInjector
 
 from notebook_intelligence.util import extract_llm_generated_code
 
 log = logging.getLogger(__name__)
+
+
+def _chat_history_context_window(chat_model) -> int:
+    """Skip history pruning when a model only guessed its window size."""
+    try:
+        is_configured = getattr(
+            chat_model,
+            "context_window_is_configured",
+            True,
+        )
+        context_window = chat_model.context_window
+    except (AttributeError, NotImplementedError):
+        return 0
+    except Exception as error:
+        log.warning(
+            "Could not resolve the chat model context window; skipping "
+            "history pruning: %s",
+            error,
+        )
+        return 0
+    return context_window if is_configured is not False else 0
 
 ICON_SVG = '<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M5.39804 10.8069C5.57428 10.9312 5.78476 10.9977 6.00043 10.9973C6.21633 10.9975 6.42686 10.93 6.60243 10.8043C6.77993 10.6739 6.91464 10.4936 6.98943 10.2863L7.43643 8.91335C7.55086 8.56906 7.74391 8.25615 8.00028 7.99943C8.25665 7.74272 8.56929 7.54924 8.91343 7.43435L10.3044 6.98335C10.4564 6.92899 10.5936 6.84019 10.7055 6.7239C10.8174 6.60762 10.9008 6.467 10.9492 6.31308C10.9977 6.15916 11.0098 5.99611 10.9847 5.83672C10.9596 5.67732 10.8979 5.52591 10.8044 5.39435C10.6703 5.20842 10.4794 5.07118 10.2604 5.00335L8.88543 4.55635C8.54091 4.44212 8.22777 4.24915 7.97087 3.99277C7.71396 3.73638 7.52035 3.42363 7.40543 3.07935L6.95343 1.69135C6.88113 1.48904 6.74761 1.31428 6.57143 1.19135C6.43877 1.09762 6.28607 1.03614 6.12548 1.01179C5.96489 0.987448 5.80083 1.00091 5.64636 1.05111C5.49188 1.1013 5.35125 1.18685 5.23564 1.30095C5.12004 1.41505 5.03265 1.55454 4.98043 1.70835L4.52343 3.10835C4.40884 3.44317 4.21967 3.74758 3.97022 3.9986C3.72076 4.24962 3.41753 4.44067 3.08343 4.55735L1.69243 5.00535C1.54065 5.05974 1.40352 5.14852 1.29177 5.26474C1.18001 5.38095 1.09666 5.52145 1.04824 5.67523C0.999819 5.82902 0.987639 5.99192 1.01265 6.1512C1.03767 6.31048 1.0992 6.46181 1.19243 6.59335C1.32027 6.7728 1.50105 6.90777 1.70943 6.97935L3.08343 7.42435C3.52354 7.57083 3.90999 7.84518 4.19343 8.21235C4.35585 8.42298 4.4813 8.65968 4.56443 8.91235L5.01643 10.3033C5.08846 10.5066 5.22179 10.6826 5.39804 10.8069ZM5.48343 3.39235L6.01043 2.01535L6.44943 3.39235C6.61312 3.8855 6.88991 4.33351 7.25767 4.70058C7.62544 5.06765 8.07397 5.34359 8.56743 5.50635L9.97343 6.03535L8.59143 6.48335C8.09866 6.64764 7.65095 6.92451 7.28382 7.29198C6.9167 7.65945 6.64026 8.10742 6.47643 8.60035L5.95343 9.97835L5.50443 8.59935C5.34335 8.10608 5.06943 7.65718 4.70443 7.28835C4.3356 6.92031 3.88653 6.64272 3.39243 6.47735L2.01443 5.95535L3.40043 5.50535C3.88672 5.33672 4.32775 5.05855 4.68943 4.69235C5.04901 4.32464 5.32049 3.88016 5.48343 3.39235ZM11.5353 14.8494C11.6713 14.9456 11.8337 14.9973 12.0003 14.9974C12.1654 14.9974 12.3264 14.9464 12.4613 14.8514C12.6008 14.7529 12.7058 14.6129 12.7613 14.4514L13.0093 13.6894C13.0625 13.5309 13.1515 13.3869 13.2693 13.2684C13.3867 13.1498 13.5307 13.0611 13.6893 13.0094L14.4613 12.7574C14.619 12.7029 14.7557 12.6004 14.8523 12.4644C14.9257 12.3614 14.9736 12.2424 14.9921 12.1173C15.0106 11.9922 14.9992 11.8645 14.9588 11.7447C14.9184 11.6249 14.8501 11.5163 14.7597 11.428C14.6692 11.3396 14.5591 11.2739 14.4383 11.2364L13.6743 10.9874C13.5162 10.9348 13.3724 10.8462 13.2544 10.7285C13.1364 10.6109 13.0473 10.4674 12.9943 10.3094L12.7423 9.53638C12.6886 9.37853 12.586 9.24191 12.4493 9.14638C12.3473 9.07343 12.2295 9.02549 12.1056 9.00642C11.9816 8.98736 11.8549 8.99772 11.7357 9.03665C11.6164 9.07558 11.508 9.142 11.4192 9.23054C11.3304 9.31909 11.2636 9.42727 11.2243 9.54638L10.9773 10.3084C10.925 10.466 10.8375 10.6097 10.7213 10.7284C10.6066 10.8449 10.4667 10.9335 10.3123 10.9874L9.53931 11.2394C9.38025 11.2933 9.2422 11.3959 9.1447 11.5326C9.04721 11.6694 8.99522 11.8333 8.99611 12.0013C8.99699 12.1692 9.0507 12.3326 9.14963 12.4683C9.24856 12.604 9.38769 12.7051 9.54731 12.7574L10.3103 13.0044C10.4692 13.0578 10.6136 13.1471 10.7323 13.2654C10.8505 13.3836 10.939 13.5283 10.9903 13.6874L11.2433 14.4614C11.2981 14.6178 11.4001 14.7534 11.5353 14.8494ZM10.6223 12.0564L10.4433 11.9974L10.6273 11.9334C10.9291 11.8284 11.2027 11.6556 11.4273 11.4284C11.6537 11.1994 11.8248 10.9216 11.9273 10.6164L11.9853 10.4384L12.0443 10.6194C12.1463 10.9261 12.3185 11.2047 12.5471 11.4332C12.7757 11.6617 13.0545 11.8336 13.3613 11.9354L13.5563 11.9984L13.3763 12.0574C13.0689 12.1596 12.7898 12.3322 12.5611 12.5616C12.3324 12.791 12.1606 13.0707 12.0593 13.3784L12.0003 13.5594L11.9423 13.3784C11.8409 13.0702 11.6687 12.7901 11.4394 12.5605C11.2102 12.3309 10.9303 12.1583 10.6223 12.0564Z"/></svg>'
 ICON_URL = f"data:image/svg+xml;base64,{base64.b64encode(ICON_SVG.encode('utf-8')).decode('utf-8')}"
@@ -452,6 +474,12 @@ class BaseChatParticipant(ChatParticipant):
         language = request.language or 'python'
         messages.insert(0, {"role": "system", "content": f"You are an assistant that creates {language} code which will be used in a Jupyter notebook. Generate only {language} code and some comments for the code. You should return the code directly, without wrapping it inside ```."})
         messages.append({"role": "user", "content": f"Generate code for: {request.prompt}"})
+        messages = budget_chat_messages(
+            messages,
+            _chat_history_context_window(chat_model),
+            request.mcp_prompt_message_count,
+            request.required_context_message_count,
+        )
         generated = chat_model.completions(messages)
         code = generated['choices'][0]['message']['content']
         
@@ -463,6 +491,12 @@ class BaseChatParticipant(ChatParticipant):
         messages.pop()
         messages.insert(0, {"role": "system", "content": f"You are an assistant that explains the provided code using markdown. Don't include any code, just narrative markdown text. Keep it concise, only generate few lines. First create a title that suits the code and then explain the code briefly. You should return the markdown directly, without wrapping it inside ```."})
         messages.append({"role": "user", "content": f"Generate markdown that explains this code: {code}"})
+        messages = budget_chat_messages(
+            messages,
+            _chat_history_context_window(chat_model),
+            request.mcp_prompt_message_count,
+            request.required_context_message_count,
+        )
         generated = chat_model.completions(messages)
         markdown = generated['choices'][0]['message']['content']
 
@@ -539,6 +573,12 @@ class BaseChatParticipant(ChatParticipant):
             messages.pop()
             messages.insert(0, {"role": "system", "content": f"You are an assistant that creates Python code. You should return the code directly, without wrapping it inside ```."})
             messages.append({"role": "user", "content": f"Generate code for: {request.prompt}"})
+            messages = budget_chat_messages(
+                messages,
+                _chat_history_context_window(chat_model),
+                request.mcp_prompt_message_count,
+                request.required_context_message_count,
+            )
             generated = chat_model.completions(messages)
             code = generated['choices'][0]['message']['content']
             code = extract_llm_generated_code(code)
@@ -560,6 +600,12 @@ class BaseChatParticipant(ChatParticipant):
         messages = [
             {"role": "system", "content": enhanced_system_prompt},
         ] + request.chat_history
+        messages = budget_chat_messages(
+            messages,
+            _chat_history_context_window(chat_model),
+            request.mcp_prompt_message_count,
+            request.required_context_message_count,
+        )
 
         try:
             if chat_model.provider.id != "github-copilot":

--- a/notebook_intelligence/chat_history_budget.py
+++ b/notebook_intelligence/chat_history_budget.py
@@ -1,0 +1,919 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from typing import Any
+
+import tiktoken
+
+
+CHAT_INPUT_BUDGET_RATIO = 0.8
+MESSAGE_OVERHEAD_TOKENS = 4
+# Exact vision token cost varies by provider, resolution, and detail mode. Use
+# a deliberately high cross-provider allowance rather than the much smaller
+# cost of a typical tiled image. Screening is higher again so image-heavy
+# requests reliably enter the full budgeting path.
+IMAGE_TOKEN_ESTIMATE = 4_096
+IMAGE_TOKEN_SCREENING_ESTIMATE = 8_192
+CONTEXT_OMISSION_NOTICE = (
+    "\n\n[Context note: Some earlier conversation or attached context was "
+    "omitted or truncated to fit the model context window.]"
+)
+SHORT_CONTEXT_OMISSION_NOTICE = "\n\n[Context omitted to fit model window.]"
+TRUNCATION_MARKER = "\n...[truncated to fit model context]"
+
+log = logging.getLogger(__name__)
+_TOKENIZER_MAX_LOAD_ATTEMPTS = 3
+_TOKENIZER_LOAD_TIMEOUT_SECONDS = 30
+_TOKENIZER_RETRY_BACKOFF_SECONDS = 300
+_TOKENIZER_FALLBACK_WARNING_INTERVAL_SECONDS = 300
+_IMAGE_OMISSION_TEXT = "[Image omitted.]"
+_ADDITIONAL_GUIDELINES_HEADER = "# Additional Guidelines\n"
+_ADDITIONAL_GUIDELINES_MARKER = (
+    "\n\n" + _ADDITIONAL_GUIDELINES_HEADER
+)
+_CELL_OUTPUT_CLOSE_RE = re.compile(r"\n</notebook-cell-[0-9a-f]+>$")
+_tokenizer_lock = threading.Lock()
+_tokenizer_encoding: Any | None = None
+_tokenizer_load_attempts = 0
+_tokenizer_load_in_progress = False
+_tokenizer_load_started_at = 0.0
+_tokenizer_last_load_failure_at = 0.0
+_tokenizer_load_generation = 0
+_tokenizer_fallback_last_logged_at: float | None = None
+
+
+def _load_tokenizer_encoding(load_generation: int) -> None:
+    global _tokenizer_encoding, _tokenizer_load_in_progress
+    global _tokenizer_load_attempts, _tokenizer_load_started_at
+    global _tokenizer_last_load_failure_at
+    encoding = None
+    try:
+        encoding = tiktoken.encoding_for_model("gpt-4o")
+    except Exception as error:
+        log.warning(
+            "Could not warm the gpt-4o tokenizer; using the UTF-8 size "
+            "fallback until a later retry succeeds: %s",
+            error,
+        )
+    finally:
+        with _tokenizer_lock:
+            if encoding is not None:
+                _tokenizer_encoding = encoding
+                _tokenizer_load_attempts = 0
+                _tokenizer_last_load_failure_at = 0.0
+            elif load_generation == _tokenizer_load_generation:
+                _tokenizer_last_load_failure_at = time.monotonic()
+            if (
+                encoding is not None
+                or load_generation == _tokenizer_load_generation
+            ):
+                _tokenizer_load_in_progress = False
+                _tokenizer_load_started_at = 0.0
+
+
+def warm_tokenizer_encoding() -> None:
+    """Warm tokenizer data asynchronously, retrying transient failures."""
+    global _tokenizer_load_attempts, _tokenizer_load_in_progress
+    global _tokenizer_load_started_at, _tokenizer_load_generation
+    global _tokenizer_last_load_failure_at
+    stale_load = False
+    with _tokenizer_lock:
+        if _tokenizer_encoding is not None:
+            return
+        now = time.monotonic()
+        if _tokenizer_load_in_progress:
+            if (
+                now - _tokenizer_load_started_at
+                < _TOKENIZER_LOAD_TIMEOUT_SECONDS
+            ):
+                return
+            stale_load = True
+            _tokenizer_load_in_progress = False
+            _tokenizer_last_load_failure_at = now
+        if _tokenizer_load_attempts >= _TOKENIZER_MAX_LOAD_ATTEMPTS:
+            if (
+                _tokenizer_last_load_failure_at <= 0
+                or now - _tokenizer_last_load_failure_at
+                < _TOKENIZER_RETRY_BACKOFF_SECONDS
+            ):
+                return
+            _tokenizer_load_attempts = 0
+        _tokenizer_load_attempts += 1
+        _tokenizer_load_in_progress = True
+        _tokenizer_load_started_at = now
+        _tokenizer_load_generation += 1
+        load_generation = _tokenizer_load_generation
+    if stale_load:
+        log.warning(
+            "Tokenizer warm-up exceeded %d seconds; starting a bounded retry",
+            _TOKENIZER_LOAD_TIMEOUT_SECONDS,
+        )
+    thread = threading.Thread(
+        target=_load_tokenizer_encoding,
+        args=(load_generation,),
+        name="nbi-tokenizer-warmup",
+        daemon=True,
+    )
+    try:
+        thread.start()
+    except Exception as error:
+        with _tokenizer_lock:
+            if load_generation == _tokenizer_load_generation:
+                _tokenizer_load_in_progress = False
+                _tokenizer_load_started_at = 0.0
+                _tokenizer_last_load_failure_at = time.monotonic()
+        log.warning(
+            "Could not start the tokenizer warm-up thread; using the UTF-8 "
+            "size fallback until a later retry succeeds: %s",
+            error,
+        )
+
+
+def _get_encoding():
+    with _tokenizer_lock:
+        encoding = _tokenizer_encoding
+    if encoding is None:
+        warm_tokenizer_encoding()
+        with _tokenizer_lock:
+            encoding = _tokenizer_encoding
+    return encoding
+
+
+def _warn_tokenizer_fallback() -> None:
+    global _tokenizer_fallback_last_logged_at
+    now = time.monotonic()
+    with _tokenizer_lock:
+        if (
+            _tokenizer_fallback_last_logged_at is not None
+            and now - _tokenizer_fallback_last_logged_at
+            < _TOKENIZER_FALLBACK_WARNING_INTERVAL_SECONDS
+        ):
+            return
+        _tokenizer_fallback_last_logged_at = now
+    log.warning(
+        "Using the UTF-8 size fallback for chat context budgeting while the "
+        "gpt-4o tokenizer is unavailable"
+    )
+
+
+def _fallback_text_token_count(text: str) -> int:
+    if text == "":
+        return 0
+    # One token per byte is intentionally conservative across tokenizers. A
+    # three-bytes-per-token estimate can substantially undercount symbol-heavy
+    # text and allow the fallback path to exceed the provider context window.
+    return len(text.encode("utf-8"))
+
+
+def _encode_text(encoding, text: str):
+    """Encode special-token literals as ordinary user-provided text."""
+    return encoding.encode(text, disallowed_special=())
+
+
+def text_token_count(text: str) -> int:
+    # TODO: select provider-specific tokenizers where a stable local encoder
+    # exists. The shared estimate is not exact for every provider; the output
+    # reserve reduces, but does not eliminate, that cross-tokenizer risk.
+    encoding = _get_encoding()
+    if encoding is None:
+        _warn_tokenizer_fallback()
+        return _fallback_text_token_count(text)
+    return len(_encode_text(encoding, text))
+
+
+def truncate_text(
+    text: str,
+    token_budget: int,
+    marker: str = "\n...[truncated]",
+) -> str:
+    if token_budget <= 0 or text == "":
+        return ""
+
+    encoding = _get_encoding()
+    if encoding is None:
+        _warn_tokenizer_fallback()
+        if _fallback_text_token_count(text) <= token_budget:
+            return text
+        marker_bytes = marker.encode("utf-8")
+        available_bytes = token_budget - len(marker_bytes)
+        if available_bytes <= 0:
+            return ""
+        prefix = text.encode("utf-8")[:available_bytes].decode(
+            "utf-8", errors="ignore"
+        ).rstrip()
+        return prefix + marker if prefix else ""
+
+    encoded = _encode_text(encoding, text)
+    if len(encoded) <= token_budget:
+        return text
+    marker_tokens = len(_encode_text(encoding, marker))
+    prefix_size = token_budget - marker_tokens
+    if prefix_size <= 0:
+        return ""
+
+    # BPE merges at the prefix/marker boundary can make the combined candidate
+    # a few tokens larger than the sum of its parts. Correct a bounded number
+    # of times; if the boundary remains pathological, return the marker alone.
+    for _ in range(4):
+        prefix = encoding.decode(encoded[:prefix_size]).rstrip()
+        candidate = prefix + marker
+        candidate_tokens = len(_encode_text(encoding, candidate))
+        if candidate_tokens <= token_budget:
+            return candidate
+        prefix_size -= max(1, candidate_tokens - token_budget)
+        if prefix_size <= 0:
+            break
+    return marker if marker_tokens <= token_budget else ""
+
+
+def _content_token_count(content: Any) -> int:
+    if content is None:
+        return 0
+    if isinstance(content, str):
+        return text_token_count(content)
+    if isinstance(content, list):
+        return sum(_content_token_count(item) for item in content)
+    if isinstance(content, dict):
+        content_type = content.get("type")
+        if content_type in {"image", "image_url"} or "image_url" in content:
+            return IMAGE_TOKEN_ESTIMATE
+        if content_type == "text" and isinstance(content.get("text"), str):
+            return text_token_count(content["text"])
+        return sum(
+            _content_token_count(value)
+            for key, value in content.items()
+            if key != "type"
+        )
+    return text_token_count(str(content))
+
+
+def estimate_message_tokens(message: dict) -> int:
+    """Estimate a chat message's input cost without serializing image data."""
+    tokens = MESSAGE_OVERHEAD_TOKENS + _content_token_count(
+        message.get("content")
+    )
+    for key, value in message.items():
+        if key not in {"role", "content"}:
+            tokens += _content_token_count(value)
+    return tokens
+
+
+def _content_token_screening_estimate(content: Any) -> int:
+    """Return a cheap conservative estimate without invoking the tokenizer."""
+    if content is None:
+        return 0
+    if isinstance(content, str):
+        return len(content.encode("utf-8"))
+    if isinstance(content, list):
+        return sum(_content_token_screening_estimate(item) for item in content)
+    if isinstance(content, dict):
+        content_type = content.get("type")
+        if content_type in {"image", "image_url"} or "image_url" in content:
+            return IMAGE_TOKEN_SCREENING_ESTIMATE
+        if content_type == "text" and isinstance(content.get("text"), str):
+            return len(content["text"].encode("utf-8"))
+        return sum(
+            _content_token_screening_estimate(value)
+            for key, value in content.items()
+            if key != "type"
+        )
+    return len(str(content).encode("utf-8"))
+
+
+def _message_token_screening_estimate(message: dict) -> int:
+    tokens = MESSAGE_OVERHEAD_TOKENS + _content_token_screening_estimate(
+        message.get("content")
+    )
+    for key, value in message.items():
+        if key not in {"role", "content"}:
+            tokens += _content_token_screening_estimate(value)
+    return tokens
+
+
+def _truncate_text_message(message: dict, token_budget: int) -> dict | None:
+    content = message.get("content")
+    if not isinstance(content, str):
+        return None
+
+    fixed_fields = message.copy()
+    fixed_fields["content"] = ""
+    content_budget = token_budget - estimate_message_tokens(fixed_fields)
+    truncated_content = truncate_text(
+        content,
+        content_budget,
+        TRUNCATION_MARKER,
+    )
+    if truncated_content == "":
+        return None
+
+    truncated = message.copy()
+    truncated["content"] = truncated_content
+    return truncated
+
+
+def _truncate_mandatory_message(
+    message: dict,
+    token_budget: int,
+) -> dict | None:
+    if isinstance(message.get("content"), str):
+        return _truncate_text_message(message, token_budget)
+
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+    text_parts = []
+    omitted_non_text = False
+    for item in content:
+        if isinstance(item, str):
+            text_parts.append(item)
+        elif (
+            isinstance(item, dict)
+            and item.get("type") == "text"
+            and isinstance(item.get("text"), str)
+        ):
+            text_parts.append(item["text"])
+        else:
+            omitted_non_text = True
+    if omitted_non_text:
+        text_parts.insert(0, _IMAGE_OMISSION_TEXT)
+    elif not text_parts:
+        text_parts.append(_IMAGE_OMISSION_TEXT)
+
+    text_message = message.copy()
+    text_message["content"] = "\n".join(text_parts)
+    truncated = _truncate_text_message(text_message, token_budget)
+    if truncated is None:
+        return None
+    if omitted_non_text and not truncated["content"].startswith(
+        _IMAGE_OMISSION_TEXT
+    ):
+        return None
+    truncated["content"] = [
+        {"type": "text", "text": truncated["content"]}
+    ]
+    return truncated
+
+
+def _has_protected_context_delimiter(message: dict) -> bool:
+    content = message.get("content")
+    if not isinstance(content, str):
+        return False
+    # Any fenced context must remain whole: file attachments, inline-edit
+    # selections, and legacy selected-cell input/output all use code fences.
+    if "```" in content:
+        return True
+    return _CELL_OUTPUT_CLOSE_RE.search(content) is not None
+
+
+def _partition_turns(
+    messages: list[dict],
+) -> tuple[list[list[dict]], list[dict]]:
+    """Split complete user turns from the unfinished trailing sequence."""
+    turns = []
+    current_turn = []
+    for message in messages:
+        role = message.get("role")
+        if role == "user" and any(
+            item.get("role") in {"assistant", "tool"}
+            for item in current_turn
+        ):
+            # A new user message cannot continue an unfinished tool-call
+            # exchange. Discard that incomplete turn and start a fresh one.
+            current_turn = [message]
+            continue
+        if not current_turn:
+            if role != "user":
+                continue
+            current_turn = [message]
+        else:
+            current_turn.append(message)
+
+        if role == "assistant" and not message.get("tool_calls"):
+            turns.append(current_turn)
+            current_turn = []
+    return turns, current_turn
+
+
+def _with_omission_notice(
+    system_messages: list[dict],
+    notice: str = CONTEXT_OMISSION_NOTICE,
+    prepend: bool = False,
+) -> list[dict]:
+    updated = [message.copy() for message in system_messages]
+    if prepend:
+        if updated and isinstance(updated[0].get("content"), str):
+            updated[0]["content"] = (
+                notice.strip() + "\n\n" + updated[0]["content"]
+            )
+        else:
+            updated.insert(0, {"role": "system", "content": notice.strip()})
+    elif updated and isinstance(updated[-1].get("content"), str):
+        updated[-1]["content"] += notice
+    else:
+        updated.append({"role": "system", "content": notice.strip()})
+    return updated
+
+
+def _join_protected_system_sections(
+    notice: str,
+    base_prompt: str,
+    guidelines: str,
+) -> str:
+    return "\n\n".join(
+        section for section in (notice, base_prompt, guidelines) if section
+    )
+
+
+def _truncate_system_prompt_preserving_guidelines(
+    content: str,
+    token_budget: int,
+) -> dict | None:
+    if content.startswith(_ADDITIONAL_GUIDELINES_HEADER):
+        base_prompt = ""
+        guidelines = content
+    else:
+        guidelines_index = content.find(_ADDITIONAL_GUIDELINES_MARKER)
+        if guidelines_index < 0:
+            return None
+        base_prompt = content[:guidelines_index]
+        guidelines = content[guidelines_index + len("\n\n"):]
+    protected_notice = SHORT_CONTEXT_OMISSION_NOTICE.strip()
+    notice = ""
+    if base_prompt.startswith(protected_notice):
+        notice = protected_notice
+        base_prompt = base_prompt[len(protected_notice):].lstrip("\n")
+    base_prompt = base_prompt.rstrip()
+
+    protected_content = _join_protected_system_sections(
+        notice,
+        "",
+        guidelines,
+    )
+    protected_message = {"role": "system", "content": protected_content}
+    protected_tokens = estimate_message_tokens(protected_message)
+    if protected_tokens > token_budget:
+        # Never silently cut repository or workspace rules. The caller will
+        # fail open if the protected rules and newest request cannot coexist.
+        return protected_message
+
+    separator_tokens = text_token_count("\n\n") if base_prompt else 0
+    base_budget = max(
+        0,
+        token_budget - protected_tokens - separator_tokens,
+    )
+    for _ in range(4):
+        truncated_base = truncate_text(
+            base_prompt,
+            base_budget,
+            TRUNCATION_MARKER,
+        )
+        candidate = {
+            "role": "system",
+            "content": _join_protected_system_sections(
+                notice,
+                truncated_base,
+                guidelines,
+            ),
+        }
+        candidate_tokens = estimate_message_tokens(candidate)
+        if candidate_tokens <= token_budget:
+            return candidate
+        base_budget -= max(1, candidate_tokens - token_budget)
+        if base_budget <= 0:
+            break
+    return protected_message
+
+
+def _truncate_system_messages(
+    system_messages: list[dict],
+    token_budget: int,
+) -> list[dict]:
+    if token_budget <= 0:
+        return []
+    if sum(estimate_message_tokens(message) for message in system_messages) <= token_budget:
+        return list(system_messages)
+
+    text_parts = [
+        message["content"]
+        for message in system_messages
+        if isinstance(message.get("content"), str)
+    ]
+    if not text_parts:
+        return []
+    combined = {"role": "system", "content": "\n\n".join(text_parts)}
+    protected = _truncate_system_prompt_preserving_guidelines(
+        combined["content"],
+        token_budget,
+    )
+    if protected is not None:
+        return [protected]
+    truncated = _truncate_text_message(combined, token_budget)
+    protected_notice = SHORT_CONTEXT_OMISSION_NOTICE.strip()
+    if (
+        combined["content"].startswith(protected_notice)
+        and (
+            truncated is None
+            or not truncated["content"].startswith(protected_notice)
+        )
+    ):
+        notice_message = {"role": "system", "content": protected_notice}
+        if estimate_message_tokens(notice_message) <= token_budget:
+            return [notice_message]
+    return [truncated] if truncated is not None else []
+
+
+def _budget_chat_messages(
+    messages: list[dict],
+    context_window: int,
+    mcp_prompt_message_count: int = 0,
+    required_context_message_count: int = 0,
+) -> list[dict]:
+    """Fit ask-mode messages to a model window without splitting old turns.
+
+    The system prompt, explicitly required current context, and newest user
+    message are mandatory. A current-request MCP prompt sequence is kept
+    atomic and prioritized next, followed by other current-turn context that
+    may be truncated when it is plain text. Complete prior turns then fill the
+    remaining budget from newest to oldest.
+    """
+    if not isinstance(context_window, int) or context_window <= 0:
+        return list(messages)
+
+    input_budget = max(1, int(context_window * CHAT_INPUT_BUDGET_RATIO))
+    if sum(
+        _message_token_screening_estimate(message) for message in messages
+    ) <= input_budget:
+        return list(messages)
+
+    token_cache = {}
+
+    def message_tokens(message: dict) -> int:
+        cache_key = id(message)
+        cached = token_cache.get(cache_key)
+        if cached is None or cached[0] is not message:
+            cached = (message, estimate_message_tokens(message))
+            # Retaining the object alongside its estimate prevents Python
+            # from reusing its id for a later omission-notice candidate.
+            token_cache[cache_key] = cached
+        return cached[1]
+
+    total_tokens = 0
+    for message in messages:
+        total_tokens += message_tokens(message)
+        if total_tokens > input_budget:
+            break
+    else:
+        # Budgeting is not a general history normalizer. Preserve unusual but
+        # accepted provider sequences byte-for-byte until pruning is required.
+        return list(messages)
+
+    system_end = 0
+    while (
+        system_end < len(messages)
+        and messages[system_end].get("role") == "system"
+    ):
+        system_end += 1
+    system_messages = messages[:system_end]
+    conversation = messages[system_end:]
+
+    latest_user_index = next(
+        (
+            index
+            for index in range(len(conversation) - 1, -1, -1)
+            if conversation[index].get("role") == "user"
+        ),
+        None,
+    )
+    if latest_user_index is None:
+        log.warning(
+            "Reducing over-budget chat history while preserving system "
+            "instructions because it has no user request"
+        )
+        if not conversation:
+            truncated_system_messages = _truncate_system_messages(
+                _with_omission_notice(
+                    system_messages,
+                    SHORT_CONTEXT_OMISSION_NOTICE,
+                    prepend=True,
+                ),
+                input_budget,
+            )
+            return truncated_system_messages or list(messages)
+
+        newest_message = conversation[-1]
+        candidate_system_messages = _with_omission_notice(
+            system_messages,
+            SHORT_CONTEXT_OMISSION_NOTICE,
+            prepend=True,
+        )
+        newest_message_tokens = message_tokens(newest_message)
+        minimum_newest_budget = MESSAGE_OVERHEAD_TOKENS + text_token_count(
+            TRUNCATION_MARKER
+        )
+        newest_message_budget = min(
+            input_budget,
+            newest_message_tokens
+            if newest_message_tokens <= input_budget
+            else max(minimum_newest_budget, input_budget // 2),
+        )
+        candidate_system_messages = _truncate_system_messages(
+            candidate_system_messages,
+            max(0, input_budget - newest_message_budget),
+        )
+        remaining_for_newest = input_budget - sum(
+            message_tokens(message) for message in candidate_system_messages
+        )
+        truncated_message = (
+            newest_message
+            if newest_message_tokens <= remaining_for_newest
+            else _truncate_mandatory_message(
+                newest_message,
+                remaining_for_newest,
+            )
+        )
+        if truncated_message is not None:
+            return [*candidate_system_messages, truncated_message]
+        return list(messages)
+
+    latest_user = conversation[latest_user_index]
+    trailing_message_count = len(conversation) - latest_user_index - 1
+    if trailing_message_count:
+        log.warning(
+            "Dropping %d trailing non-user chat messages while pruning; "
+            "the newest user request must terminate an API chat request",
+            trailing_message_count,
+        )
+    preceding_messages = conversation[:latest_user_index]
+    if (
+        not isinstance(mcp_prompt_message_count, int)
+        or isinstance(mcp_prompt_message_count, bool)
+        or mcp_prompt_message_count < 0
+    ):
+        mcp_prompt_message_count = 0
+    mcp_prompt_message_count = min(
+        mcp_prompt_message_count,
+        len(preceding_messages),
+    )
+    if mcp_prompt_message_count:
+        mcp_prompt_messages = preceding_messages[-mcp_prompt_message_count:]
+        historical_messages = preceding_messages[:-mcp_prompt_message_count]
+    else:
+        mcp_prompt_messages = []
+        historical_messages = preceding_messages
+
+    if (
+        not isinstance(required_context_message_count, int)
+        or isinstance(required_context_message_count, bool)
+        or required_context_message_count < 0
+    ):
+        required_context_message_count = 0
+    required_context_message_count = min(
+        required_context_message_count,
+        len(historical_messages),
+    )
+    if required_context_message_count:
+        required_context_messages = historical_messages[
+            -required_context_message_count:
+        ]
+        historical_messages = historical_messages[
+            :-required_context_message_count
+        ]
+    else:
+        required_context_messages = []
+
+    complete_turns, trailing_sequence = _partition_turns(
+        historical_messages
+    )
+    current_context = (
+        trailing_sequence
+        if all(message.get("role") == "user" for message in trailing_sequence)
+        else []
+    )
+    base_mandatory_messages = [
+        *system_messages,
+        *required_context_messages,
+        latest_user,
+    ]
+    base_mandatory_tokens = sum(
+        message_tokens(message)
+        for message in base_mandatory_messages
+    )
+    if base_mandatory_tokens > input_budget:
+        if any(
+            _ADDITIONAL_GUIDELINES_HEADER
+            in str(message.get("content", ""))
+            for message in system_messages
+        ):
+            log.warning(
+                "Application instructions and injected guidelines cannot both "
+                "fit the %d-token input budget; sending the original request "
+                "instead of dropping either instruction layer",
+                input_budget,
+            )
+            return list(messages)
+        if required_context_messages:
+            log.warning(
+                "Required current-request context cannot fit the %d-token "
+                "input budget; sending the original request so the provider "
+                "returns a visible context-limit error instead of generating "
+                "without required source context",
+                input_budget,
+            )
+            return list(messages)
+        candidate_system_messages = _with_omission_notice(
+            system_messages,
+            SHORT_CONTEXT_OMISSION_NOTICE,
+            prepend=True,
+        )
+        non_user_mandatory_tokens = sum(
+            message_tokens(message)
+            for message in candidate_system_messages
+        )
+        truncated_latest_user = _truncate_mandatory_message(
+            latest_user,
+            max(0, input_budget - non_user_mandatory_tokens),
+        )
+        if truncated_latest_user is None:
+            # When configured system instructions consume the whole model
+            # window, reserve half the input budget for the actual request and
+            # truncate both sides. Extremely tiny windows may still be unable
+            # to fit even the per-message protocol overhead; those fall open.
+            minimum_user_budget = MESSAGE_OVERHEAD_TOKENS + text_token_count(
+                _IMAGE_OMISSION_TEXT + "\n" + TRUNCATION_MARKER
+            )
+            latest_user_tokens = message_tokens(latest_user)
+            user_budget = min(
+                input_budget,
+                latest_user_tokens
+                if latest_user_tokens <= input_budget
+                else max(minimum_user_budget, input_budget // 2),
+            )
+            candidate_system_messages = _truncate_system_messages(
+                candidate_system_messages,
+                max(0, input_budget - user_budget),
+            )
+            remaining_for_user = input_budget - sum(
+                message_tokens(message)
+                for message in candidate_system_messages
+            )
+            truncated_latest_user = _truncate_mandatory_message(
+                latest_user,
+                remaining_for_user,
+            )
+            if truncated_latest_user is None:
+                has_protected_guidelines = any(
+                    _ADDITIONAL_GUIDELINES_HEADER
+                    in str(message.get("content", ""))
+                    for message in candidate_system_messages
+                )
+                if not has_protected_guidelines:
+                    notice_message = {
+                        "role": "system",
+                        "content": SHORT_CONTEXT_OMISSION_NOTICE.strip(),
+                    }
+                    candidate_system_messages = (
+                        [notice_message]
+                        if message_tokens(notice_message) < input_budget
+                        else []
+                    )
+                    truncated_latest_user = _truncate_mandatory_message(
+                        latest_user,
+                        input_budget
+                        - sum(
+                            message_tokens(message)
+                            for message in candidate_system_messages
+                        ),
+                    )
+        if truncated_latest_user is not None:
+            log.warning(
+                "Truncating mandatory system or user context because it "
+                "requires %d estimated tokens for a %d-token input budget",
+                base_mandatory_tokens,
+                input_budget,
+            )
+            system_messages = candidate_system_messages
+            latest_user = truncated_latest_user
+        else:
+            log.warning(
+                "Mandatory chat context requires %d estimated tokens, "
+                "exceeding the %d-token input budget; the system prompt "
+                "leaves too little room to truncate the newest user request",
+                base_mandatory_tokens,
+                input_budget,
+            )
+    else:
+        for notice in (
+            CONTEXT_OMISSION_NOTICE,
+            SHORT_CONTEXT_OMISSION_NOTICE,
+        ):
+            candidate_system_messages = _with_omission_notice(
+                system_messages,
+                notice,
+            )
+            candidate_mandatory_messages = [
+                *candidate_system_messages,
+                *required_context_messages,
+                latest_user,
+            ]
+            if sum(
+                message_tokens(message)
+                for message in candidate_mandatory_messages
+            ) <= input_budget:
+                system_messages = candidate_system_messages
+                break
+
+    mandatory_messages = [
+        *system_messages,
+        *required_context_messages,
+        latest_user,
+    ]
+    remaining_budget = max(
+        0,
+        input_budget
+        - sum(
+            message_tokens(message)
+            for message in mandatory_messages
+        ),
+    )
+
+    selected_mcp_prompt = []
+    if mcp_prompt_messages:
+        mcp_prompt_tokens = sum(
+            message_tokens(message) for message in mcp_prompt_messages
+        )
+        if mcp_prompt_tokens <= remaining_budget:
+            selected_mcp_prompt = mcp_prompt_messages
+            remaining_budget -= mcp_prompt_tokens
+        else:
+            log.warning(
+                "Dropping a %d-message MCP prompt requiring %d estimated "
+                "tokens because only %d tokens remain after mandatory "
+                "system and user context",
+                len(mcp_prompt_messages),
+                mcp_prompt_tokens,
+                remaining_budget,
+            )
+
+    selected_context = []
+    for message in reversed(current_context):
+        context_tokens = message_tokens(message)
+        if context_tokens <= remaining_budget:
+            selected_context.append(message)
+            remaining_budget -= context_tokens
+            continue
+
+        # File fences and nonced cell-output envelopes contain untrusted data.
+        # Drop them whole if they do not fit; prefix truncation would remove
+        # the closing delimiter that keeps their payload clearly bounded.
+        if _has_protected_context_delimiter(message):
+            continue
+        truncated = _truncate_text_message(message, remaining_budget)
+        if truncated is not None:
+            selected_context.append(truncated)
+            remaining_budget -= message_tokens(truncated)
+        continue
+    selected_context.reverse()
+
+    selected_turns = []
+    for turn in reversed(complete_turns):
+        turn_tokens = sum(message_tokens(message) for message in turn)
+        if turn_tokens > remaining_budget:
+            break
+        selected_turns.append(turn)
+        remaining_budget -= turn_tokens
+    selected_turns.reverse()
+
+    return [
+        *system_messages,
+        *(message for turn in selected_turns for message in turn),
+        *selected_context,
+        *required_context_messages,
+        *selected_mcp_prompt,
+        latest_user,
+    ]
+
+
+def budget_chat_messages(
+    messages: list[dict],
+    context_window: int,
+    mcp_prompt_message_count: int = 0,
+    required_context_message_count: int = 0,
+) -> list[dict]:
+    """Fail open if estimation encounters malformed data or runtime errors."""
+    try:
+        return _budget_chat_messages(
+            messages,
+            context_window,
+            mcp_prompt_message_count,
+            required_context_message_count,
+        )
+    except Exception:
+        log.exception(
+            "Could not budget chat history; sending the original messages"
+        )
+        return list(messages)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -18,7 +18,6 @@ from typing import Optional, Union
 import uuid
 import threading
 import logging
-import tiktoken
 
 from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.auth.decorator import ws_authenticated
@@ -81,6 +80,12 @@ from notebook_intelligence.claude import (
     resolve_permission_mode,
 )
 from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
+from notebook_intelligence.chat_history_budget import (
+    CHAT_INPUT_BUDGET_RATIO,
+    text_token_count as _token_count,
+    truncate_text as _truncate_context_content,
+    warm_tokenizer_encoding,
+)
 from notebook_intelligence.plugin_manager import PluginManager
 from notebook_intelligence.prompts import Prompts
 from notebook_intelligence.tour_config import load_tour_config
@@ -147,29 +152,7 @@ def _stream_chunk_byte_estimate(data) -> int:
     # when diagnostics are on, and it is still far cheaper than the
     # asdict + json.dumps this replaced.
     return len(content.encode("utf-8", errors="ignore"))
-
-
-tiktoken_encoding = tiktoken.encoding_for_model('gpt-4o')
 thread_safe_websocket_connector: ThreadSafeWebSocketConnector = None
-
-
-def _token_count(text: str) -> int:
-    return len(tiktoken_encoding.encode(text))
-
-
-def _truncate_context_content(content: str, token_budget: int) -> str:
-    if token_budget <= 0 or content == '':
-        return ''
-
-    encoded = tiktoken_encoding.encode(content)
-    if len(encoded) <= token_budget:
-        return content
-
-    truncated = tiktoken_encoding.decode(encoded[:token_budget]).rstrip()
-    if truncated == '':
-        return ''
-
-    return truncated + "\n...[truncated]"
 
 
 def _inline_system_prompt_token_budget(
@@ -178,7 +161,9 @@ def _inline_system_prompt_token_budget(
     base_system_prompt: str,
 ) -> int:
     """Reserve at most 80% of context for inline history plus system text."""
-    context_budget = int(0.8 * _resolve_context_token_limit(manager))
+    context_budget = int(
+        CHAT_INPUT_BUDGET_RATIO * _resolve_context_token_limit(manager)
+    )
     history_tokens = sum(
         _token_count(message.get("content", ""))
         for message in chat_history
@@ -3233,7 +3218,7 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                     chat_history.append({"role": "user", "content": current_directory_file_msg})
 
                 token_limit = _resolve_context_token_limit(ai_service_manager)
-                remaining_token_budget = int(0.8 * token_limit)
+                remaining_token_budget = int(CHAT_INPUT_BUDGET_RATIO * token_limit)
 
                 # Resolve once; reused for sandbox containment and for
                 # workspace-relative @-mention path computation below.
@@ -3514,17 +3499,22 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                 language,
                 modifying_existing_code=existing_code != '',
             )
-            request_history = self.chat_history.get_history(chatId)
+            # AIServiceManager appends the final prompt. Exclude the persisted
+            # copy here, matching ordinary chat requests, so current-request
+            # context remains directly before that final prompt.
+            persisted_request_history = self.chat_history.get_history(chatId)
+            request_history = persisted_request_history[:-1]
+            inline_prompt = f"Generate code for: {prompt}"
             completion_options = {"system_prompt": system_prompt}
             if is_claude_code_mode:
                 completion_options["system_prompt_token_budget"] = (
                     _inline_system_prompt_token_budget(
                         ai_service_manager,
-                        request_history,
+                        persisted_request_history,
                         system_prompt,
                     )
                 )
-            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=prompt, language=language, kernel_name=kernel_name, chat_history=request_history, cancel_token=cancel_token, rule_context=rule_context), response_emitter, options=completion_options)
+            coro = ai_service_manager.handle_chat_request(ChatRequest(chat_mode=chat_mode, prompt=inline_prompt, language=language, kernel_name=kernel_name, chat_history=request_history, cancel_token=cancel_token, rule_context=rule_context, required_context_message_count=1 if existing_code != '' else 0), response_emitter, options=completion_options)
             thread = threading.Thread(target=self._run_request_thread, args=(coro, messageId, response_emitter))
             thread.start()
         elif messageType == RequestDataType.InlineCompletionRequest:
@@ -4161,7 +4151,7 @@ class NotebookIntelligence(ExtensionApp):
     )
 
     def initialize_settings(self):
-        pass
+        warm_tokenizer_encoding()
 
     def _publish_policies(self, feature_policies: dict, string_overrides: dict) -> None:
         """Wire the resolved policies into the HTTP handlers.

--- a/notebook_intelligence/github_copilot.py
+++ b/notebook_intelligence/github_copilot.py
@@ -52,7 +52,8 @@ github_auth = {
 
 # Populated from https://api.githubcopilot.com/models once the user has a
 # valid Copilot bearer token. Each entry is a normalized dict:
-# {"id": str, "name": str, "context_window": int}. Empty until the first
+# {"id": str, "name": str, "context_window": int,
+#  "context_window_is_configured": bool}. Empty until the first
 # successful fetch; the LLM provider falls back to its hardcoded list in
 # that case so the settings UI is never blank. Mutated in place by
 # `fetch_copilot_models` so module-level `from ... import` references
@@ -489,7 +490,8 @@ def fetch_copilot_models() -> list[dict]:
 
     Filters to chat models with `model_picker_enabled = true` (the same
     surface GitHub's official clients expose in their model picker), and
-    normalizes each entry to {"id": str, "name": str, "context_window": int}.
+    normalizes each entry to a model id/name, context window, and whether the
+    API supplied that window rather than the conservative local fallback.
     Stores the result in ``copilot_models_cache`` (mutated in place) so the
     LLM provider's `chat_models` property reflects the live list on the
     next access. Returns the new list; returns the existing cache unchanged
@@ -554,17 +556,19 @@ def fetch_copilot_models() -> list[dict]:
         seen_ids.add(model_id)
         name = entry.get("name") or model_id
         limits = caps.get("limits", {}) or {}
-        context_window = (
+        raw_context_window = (
             limits.get("max_context_window_tokens")
             or limits.get("max_prompt_tokens")
-            or _COPILOT_DEFAULT_CONTEXT_WINDOW
         )
+        context_window_is_configured = raw_context_window is not None
         try:
-            context_window = int(context_window)
+            context_window = int(raw_context_window)
         except (TypeError, ValueError):
             context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
+            context_window_is_configured = False
         if context_window <= 0:
             context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
+            context_window_is_configured = False
         # Prefer `/chat/completions` whenever the model advertises it; only
         # route through `/responses` when that's the model's sole supported
         # path. Mirrors codecompanion.nvim's Copilot adapter: dual-listing
@@ -578,6 +582,7 @@ def fetch_copilot_models() -> list[dict]:
             "id": model_id,
             "name": str(name),
             "context_window": context_window,
+            "context_window_is_configured": context_window_is_configured,
         })
 
     # Preserve the existing cache when the API returns an empty (but

--- a/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
+++ b/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
@@ -13,11 +13,12 @@ log = logging.getLogger(__name__)
 GH_COPILOT_EXCLUDED_MODELS = set(["o1"])
 
 class GitHubCopilotChatModel(ChatModel):
-    def __init__(self, provider: LLMProvider, model_id: str, model_name: str, context_window: int, supports_tools: bool):
+    def __init__(self, provider: LLMProvider, model_id: str, model_name: str, context_window: int, supports_tools: bool, context_window_is_configured: bool = True):
         super().__init__(provider)
         self._model_id = model_id
         self._model_name = model_name
         self._context_window = context_window
+        self._context_window_is_configured = context_window_is_configured
         self._supports_tools = supports_tools
 
     @property
@@ -31,6 +32,10 @@ class GitHubCopilotChatModel(ChatModel):
     @property
     def context_window(self) -> int:
         return self._context_window
+
+    @property
+    def context_window_is_configured(self) -> bool:
+        return self._context_window_is_configured
 
     @property
     def supports_tools(self) -> bool:
@@ -88,11 +93,25 @@ class GitHubCopilotLLMProvider(LLMProvider):
         cached = gh_copilot.copilot_models_cache
         if cached:
             return [
-                GitHubCopilotChatModel(self, entry["id"], entry["name"], entry["context_window"], True)
+                GitHubCopilotChatModel(
+                    self,
+                    entry["id"],
+                    entry["name"],
+                    entry["context_window"],
+                    True,
+                    entry.get("context_window_is_configured", True),
+                )
                 for entry in cached
             ]
         return [
-            GitHubCopilotChatModel(self, model_id, model_name, ctx, True)
+            GitHubCopilotChatModel(
+                self,
+                model_id,
+                model_name,
+                ctx,
+                True,
+                False,
+            )
             for (model_id, model_name, ctx) in self._FALLBACK_CHAT_MODELS
         ]
 
@@ -117,4 +136,3 @@ class GitHubCopilotLLMProvider(LLMProvider):
     @property
     def embedding_models(self) -> list[EmbeddingModel]:
         return []
-

--- a/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
@@ -36,6 +36,16 @@ class LiteLLMCompatibleChatModel(ChatModel):
         except:
             return DEFAULT_CONTEXT_WINDOW
 
+    @property
+    def context_window_is_configured(self) -> bool:
+        context_window_prop = self.get_property("context_window")
+        if context_window_prop is None:
+            return False
+        try:
+            return int(context_window_prop.value) > 0
+        except (TypeError, ValueError):
+            return False
+
     def completions(self, messages: list[dict], tools: list[dict] = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
         litellm = import_litellm()
         stream = response is not None

--- a/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
@@ -53,6 +53,16 @@ class OpenAICompatibleChatModel(ChatModel):
         except:
             return DEFAULT_CONTEXT_WINDOW
 
+    @property
+    def context_window_is_configured(self) -> bool:
+        context_window_prop = self.get_property("context_window")
+        if context_window_prop is None:
+            return False
+        try:
+            return int(context_window_prop.value) > 0
+        except (TypeError, ValueError):
+            return False
+
     def completions(self, messages: list[dict], tools: list[dict] = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
         from openai import OpenAI, omit
         stream = response is not None

--- a/notebook_intelligence/rule_injector.py
+++ b/notebook_intelligence/rule_injector.py
@@ -3,14 +3,15 @@
 import logging
 from pathlib import Path
 
-import tiktoken
-
 from notebook_intelligence.api import ChatRequest
+from notebook_intelligence.chat_history_budget import (
+    text_token_count,
+    truncate_text,
+)
 from notebook_intelligence.rule_manager import RuleManager
 from notebook_intelligence.util import get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
-_TOKEN_ENCODING = tiktoken.encoding_for_model("gpt-4o")
 _TRUNCATION_MARKER = "\n...[additional guidelines truncated]"
 
 
@@ -62,19 +63,17 @@ class RuleInjector:
         guidelines = "# Additional Guidelines\n" + "\n\n".join(sections)
         separator = "\n\n" if base_prompt else ""
         if max_tokens is not None:
-            base_tokens = len(_TOKEN_ENCODING.encode(base_prompt + separator))
+            base_tokens = text_token_count(base_prompt + separator)
             guideline_budget = max_tokens - base_tokens
             if guideline_budget <= 0:
                 return base_prompt
-            encoded_guidelines = _TOKEN_ENCODING.encode(guidelines)
-            if len(encoded_guidelines) > guideline_budget:
-                marker_tokens = _TOKEN_ENCODING.encode(_TRUNCATION_MARKER)
-                content_budget = guideline_budget - len(marker_tokens)
-                if content_budget <= 0:
-                    return base_prompt
-                guidelines = (
-                    _TOKEN_ENCODING.decode(encoded_guidelines[:content_budget]).rstrip()
-                    + _TRUNCATION_MARKER
+            if text_token_count(guidelines) > guideline_budget:
+                guidelines = truncate_text(
+                    guidelines,
+                    guideline_budget,
+                    _TRUNCATION_MARKER,
                 )
+                if not guidelines:
+                    return base_prompt
 
         return base_prompt + separator + guidelines

--- a/tests/test_ai_service_manager_dispatch.py
+++ b/tests/test_ai_service_manager_dispatch.py
@@ -73,6 +73,34 @@ def test_unknown_participant_fallback_preserves_parsed_command():
     assert request.command == "explain"
 
 
+def test_mcp_prompt_messages_are_marked_as_current_request_context():
+    manager, default_participant = _make_manager()
+    manager.get_mcp_server_prompt_value = Mock(
+        return_value=[
+            {"role": "assistant", "content": "Return strict JSON."},
+            {"role": "user", "content": "Use the compact schema."},
+        ]
+    )
+    request = ChatRequest(
+        prompt="/mcp:docs:review: inspect this",
+        chat_history=[
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ],
+    )
+    response = _RecordingResponse()
+
+    asyncio.run(manager.handle_chat_request(request, response))
+
+    default_participant.handle_chat_request.assert_awaited_once()
+    assert request.mcp_prompt_message_count == 2
+    assert request.chat_history[-3:] == [
+        {"role": "assistant", "content": "Return strict JSON."},
+        {"role": "user", "content": "Use the compact schema."},
+        {"role": "user", "content": "inspect this"},
+    ]
+
+
 def test_claude_mode_resolves_active_default_outside_participant_map():
     manager, _default_participant = _make_manager()
     manager._nbi_config.claude_settings = {"enabled": True}

--- a/tests/test_base_chat_participant_integration.py
+++ b/tests/test_base_chat_participant_integration.py
@@ -1,14 +1,46 @@
 import asyncio
 from unittest.mock import Mock, AsyncMock
+
+import notebook_intelligence.base_chat_participant as base_participant_module
+import notebook_intelligence.chat_history_budget as budget_module
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
 from notebook_intelligence.base_chat_participant import CreateNewNotebookTool
 from notebook_intelligence.base_chat_participant import ListAvailableNotebookKernelsTool
 from notebook_intelligence.api import ChatRequest, ChatResponse, ChatMode, CancelToken
+from notebook_intelligence.chat_history_budget import (
+    CHAT_INPUT_BUDGET_RATIO,
+    TRUNCATION_MARKER,
+    estimate_message_tokens,
+)
 from notebook_intelligence.ruleset import RuleContext
 from notebook_intelligence.rule_injector import RuleInjector
 
 
 class TestBaseChatParticipantIntegration:
+    def test_history_budget_uses_window_for_models_without_configured_flag(self):
+        class LegacyChatModel:
+            context_window = 8192
+
+        assert (
+            base_participant_module._chat_history_context_window(
+                LegacyChatModel()
+            )
+            == 8192
+        )
+
+    def test_history_budget_fails_open_when_window_lookup_raises(self):
+        class BrokenChatModel:
+            @property
+            def context_window(self):
+                raise NotImplementedError
+
+        assert (
+            base_participant_module._chat_history_context_window(
+                BrokenChatModel()
+            )
+            == 0
+        )
+
     def test_init_with_default_rule_injector(self):
         """Test BaseChatParticipant initialization with default rule injector."""
         participant = BaseChatParticipant()
@@ -90,8 +122,153 @@ class TestBaseChatParticipantIntegration:
         assert messages[0]["role"] == "system"
         assert messages[0]["content"] == "Enhanced system prompt"
 
-    def test_handle_chat_request_agent_mode_with_rules(self):
+    def test_ask_mode_budgets_oversized_history_as_complete_turns(self):
+        mock_injector = Mock(spec=RuleInjector)
+        mock_injector.inject_rules.return_value = "Enhanced system prompt"
+        participant = BaseChatParticipant(rule_injector=mock_injector)
+
+        mock_chat_model = Mock()
+        mock_chat_model.provider.name = "test-provider"
+        mock_chat_model.provider.id = "test-provider"
+        mock_chat_model.name = "test-model"
+        mock_chat_model.context_window = 256
+        mock_host = Mock()
+        mock_host.chat_model = mock_chat_model
+
+        request = ChatRequest(
+            host=mock_host,
+            chat_mode=ChatMode("ask", "Ask"),
+            prompt="current question",
+            chat_history=[
+                {"role": "user", "content": "old question " * 500},
+                {"role": "assistant", "content": "old answer " * 500},
+                {"role": "user", "content": "recent question"},
+                {"role": "assistant", "content": "recent answer"},
+                {"role": "user", "content": "current question"},
+            ],
+            cancel_token=Mock(spec=CancelToken),
+        )
+        response = Mock(spec=ChatResponse)
+
+        asyncio.run(participant.handle_ask_mode_chat_request(request, response))
+
+        messages = mock_chat_model.completions.call_args.args[0]
+        assert messages[-1]["content"] == "current question"
+        assert any(
+            message["content"] == "recent question" for message in messages
+        )
+        assert not any(
+            message["content"] == "old question " * 500 for message in messages
+        )
+
+    def test_ask_mode_fails_open_when_app_prompt_and_rules_cannot_both_fit(
+        self,
+        monkeypatch,
+    ):
+        class CharacterEncoding:
+            def encode(self, text, **_kwargs):
+                return [ord(character) for character in text]
+
+            def decode(self, tokens):
+                return "".join(chr(token) for token in tokens)
+
+        monkeypatch.setattr(
+            budget_module,
+            "_get_encoding",
+            lambda: CharacterEncoding(),
+        )
+        protected_rules = (
+            "# Additional Guidelines\n"
+            "# Repository Instructions (AGENTS.md)\n"
+            "Always use parameterized queries.\n\n"
+            "# Workspace Rules\nNever delete user data."
+        )
+        mock_injector = Mock(spec=RuleInjector)
+        mock_injector.inject_rules.return_value = (
+            "generic assistant prompt " * 500
+            + "\n\n"
+            + protected_rules
+        )
+        participant = BaseChatParticipant(rule_injector=mock_injector)
+
+        chat_model = Mock()
+        chat_model.provider.name = "test-provider"
+        chat_model.provider.id = "test-provider"
+        chat_model.name = "test-model"
+        chat_model.context_window = 512
+        host = Mock()
+        host.chat_model = chat_model
+        request = ChatRequest(
+            host=host,
+            chat_mode=ChatMode("ask", "Ask"),
+            prompt="current question",
+            chat_history=[
+                {"role": "user", "content": "current question"},
+            ],
+            cancel_token=Mock(spec=CancelToken),
+        )
+        response = Mock(spec=ChatResponse)
+
+        asyncio.run(
+            participant.handle_ask_mode_chat_request(request, response)
+        )
+
+        messages = chat_model.completions.call_args.args[0]
+        system_content = messages[0]["content"]
+        assert "Always use parameterized queries." in system_content
+        assert "Never delete user data." in system_content
+        assert TRUNCATION_MARKER not in system_content
+        assert system_content.count("generic assistant prompt") == 500
+
+    def test_builtin_generation_paths_budget_messages(self):
+        participant = BaseChatParticipant()
+        chat_model = Mock()
+        chat_model.context_window = 256
+        chat_model.completions.side_effect = [
+            {"choices": [{"message": {"content": "print('hello')"}}]},
+            {"choices": [{"message": {"content": "Generated explanation"}}]},
+            {"choices": [{"message": {"content": "print('file')"}}]},
+        ]
+        request = Mock(spec=ChatRequest)
+        request.host.chat_model = chat_model
+        request.chat_history = [
+            {"role": "user", "content": "old question " * 500},
+            {"role": "assistant", "content": "old answer " * 500},
+            {"role": "user", "content": "Generate it"},
+        ]
+        request.prompt = "Generate it"
+
+        asyncio.run(participant.generate_code_cell(request))
+        asyncio.run(participant.generate_markdown_for_code(request, "print('hello')"))
+
+        request.command = "newPythonFile"
+        response = Mock(spec=ChatResponse)
+        response.run_ui_command = AsyncMock(return_value={"path": "generated.py"})
+        asyncio.run(participant.handle_ask_mode_chat_request(request, response))
+
+        assert chat_model.completions.call_count == 3
+        for call in chat_model.completions.call_args_list:
+            messages = call.args[0]
+            assert not any(
+                message.get("content") == "old question " * 500
+                for message in messages
+            )
+            assert not any(
+                message.get("content") == "old answer " * 500
+                for message in messages
+            )
+            assert sum(
+                estimate_message_tokens(message) for message in messages
+            ) <= int(256 * CHAT_INPUT_BUDGET_RATIO)
+
+    def test_handle_chat_request_agent_mode_with_rules(self, monkeypatch):
         """Test agent mode chat request handling with rule injection."""
+        budget_mock = Mock()
+        monkeypatch.setattr(
+            base_participant_module,
+            "budget_chat_messages",
+            budget_mock,
+        )
         mock_injector = Mock(spec=RuleInjector)
         mock_injector.inject_rules.return_value = "Enhanced agent prompt"
         
@@ -153,6 +330,7 @@ class TestBaseChatParticipantIntegration:
         
         assert "system_prompt" in options
         assert options["system_prompt"] == "Enhanced agent prompt"
+        budget_mock.assert_not_called()
 
     def test_handle_ask_mode_new_notebook_uses_request_language_and_kernel(self):
         participant = BaseChatParticipant()

--- a/tests/test_chat_history_budget.py
+++ b/tests/test_chat_history_budget.py
@@ -1,0 +1,940 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+import notebook_intelligence.chat_history_budget as budget_module
+from notebook_intelligence.chat_history_budget import (
+    CHAT_INPUT_BUDGET_RATIO,
+    CONTEXT_OMISSION_NOTICE,
+    TRUNCATION_MARKER,
+    budget_chat_messages,
+    estimate_message_tokens,
+    text_token_count,
+    truncate_text,
+    warm_tokenizer_encoding,
+)
+
+
+class _CharacterEncoding:
+    def encode(self, text, **_kwargs):
+        return [ord(character) for character in text]
+
+    def decode(self, tokens):
+        return "".join(chr(token) for token in tokens)
+
+
+class _ImmediateThread:
+    def __init__(self, target, args=(), **_kwargs):
+        self.target = target
+        self.args = args
+
+    def start(self):
+        self.target(*self.args)
+
+
+@pytest.fixture(autouse=True)
+def stable_tokenizer_state(monkeypatch):
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_encoding",
+        _CharacterEncoding(),
+    )
+    monkeypatch.setattr(budget_module, "_tokenizer_load_attempts", 0)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_in_progress", False)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_started_at", 0.0)
+    monkeypatch.setattr(budget_module, "_tokenizer_last_load_failure_at", 0.0)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_generation", 0)
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_fallback_last_logged_at",
+        None,
+    )
+
+
+def test_messages_under_budget_are_unchanged():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Question"},
+    ]
+
+    assert budget_chat_messages(messages, 4096) == messages
+
+
+def test_tokenizer_encoding_is_loaded_lazily_and_cached(monkeypatch):
+    encoding = _CharacterEncoding()
+    encoding_for_model = Mock(return_value=encoding)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        budget_module.tiktoken,
+        "encoding_for_model",
+        encoding_for_model,
+    )
+
+    assert text_token_count("first") == 5
+    assert text_token_count("second") == 6
+    encoding_for_model.assert_called_once_with("gpt-4o")
+
+
+def test_tokenizer_load_failure_retries_then_caches_success(
+    monkeypatch,
+    caplog,
+):
+    encoding = _CharacterEncoding()
+    encoding_for_model = Mock(
+        side_effect=[RuntimeError("offline"), encoding]
+    )
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        budget_module.tiktoken,
+        "encoding_for_model",
+        encoding_for_model,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert text_token_count("é") == 2
+        assert text_token_count("é") == 1
+        assert text_token_count("é") == 1
+
+    assert encoding_for_model.call_count == 2
+    assert "using the UTF-8 size fallback" in caplog.text
+
+
+def test_tokenizer_load_retries_are_bounded(monkeypatch):
+    encoding_for_model = Mock(side_effect=RuntimeError("offline"))
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        budget_module.tiktoken,
+        "encoding_for_model",
+        encoding_for_model,
+    )
+
+    for _ in range(5):
+        text_token_count("abcdefgh")
+
+    assert encoding_for_model.call_count == 3
+
+
+def test_tokenizer_fallback_warning_repeats_after_interval(
+    monkeypatch,
+    caplog,
+):
+    monotonic = Mock(return_value=100.0)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_load_attempts",
+        budget_module._TOKENIZER_MAX_LOAD_ATTEMPTS,
+    )
+    monkeypatch.setattr(budget_module.time, "monotonic", monotonic)
+
+    with caplog.at_level(logging.WARNING):
+        text_token_count("first")
+        text_token_count("second")
+        monotonic.return_value = (
+            100.0
+            + budget_module._TOKENIZER_FALLBACK_WARNING_INTERVAL_SECONDS
+        )
+        text_token_count("third")
+
+    assert caplog.text.count("Using the UTF-8 size fallback") == 2
+
+
+def test_tokenizer_load_retries_after_backoff(monkeypatch):
+    encoding_for_model = Mock(
+        side_effect=[
+            RuntimeError("offline"),
+            RuntimeError("offline"),
+            RuntimeError("offline"),
+            _CharacterEncoding(),
+        ]
+    )
+    monotonic = Mock(return_value=100.0)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(budget_module.time, "monotonic", monotonic)
+    monkeypatch.setattr(
+        budget_module.tiktoken,
+        "encoding_for_model",
+        encoding_for_model,
+    )
+
+    for _ in range(4):
+        text_token_count("retry")
+
+    assert encoding_for_model.call_count == 3
+
+    monotonic.return_value = (
+        100.0 + budget_module._TOKENIZER_RETRY_BACKOFF_SECONDS
+    )
+
+    assert text_token_count("retry") == 5
+    assert encoding_for_model.call_count == 4
+    assert budget_module._tokenizer_load_attempts == 0
+
+
+def test_stale_tokenizer_load_allows_a_bounded_retry(monkeypatch, caplog):
+    thread = Mock()
+    thread_class = Mock(return_value=thread)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_attempts", 1)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_in_progress", True)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_started_at", 10.0)
+    monkeypatch.setattr(budget_module.time, "monotonic", Mock(return_value=41.0))
+    monkeypatch.setattr(budget_module.threading, "Thread", thread_class)
+
+    with caplog.at_level(logging.WARNING):
+        warm_tokenizer_encoding()
+
+    assert budget_module._tokenizer_load_attempts == 2
+    thread.start.assert_called_once_with()
+    assert "starting a bounded retry" in caplog.text
+
+
+def test_three_stale_tokenizer_loads_recover_after_backoff(monkeypatch):
+    thread = Mock()
+    thread_class = Mock(return_value=thread)
+    monotonic = Mock(return_value=41.0)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_load_attempts",
+        budget_module._TOKENIZER_MAX_LOAD_ATTEMPTS,
+    )
+    monkeypatch.setattr(budget_module, "_tokenizer_load_in_progress", True)
+    monkeypatch.setattr(budget_module, "_tokenizer_load_started_at", 10.0)
+    monkeypatch.setattr(budget_module.time, "monotonic", monotonic)
+    monkeypatch.setattr(budget_module.threading, "Thread", thread_class)
+
+    warm_tokenizer_encoding()
+
+    thread.start.assert_not_called()
+    assert budget_module._tokenizer_last_load_failure_at == 41.0
+
+    monotonic.return_value = (
+        41.0 + budget_module._TOKENIZER_RETRY_BACKOFF_SECONDS
+    )
+    warm_tokenizer_encoding()
+
+    thread.start.assert_called_once_with()
+
+
+def test_tokenizer_truncation_uses_a_bounded_number_of_encodes(monkeypatch):
+    text = "a" * 1000
+    encoding = Mock(wraps=_CharacterEncoding())
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", encoding)
+
+    truncated = truncate_text(text, 100)
+
+    assert truncated.endswith("\n...[truncated]")
+    assert encoding.encode.call_count <= 6
+    assert sum(call.args[0] == text for call in encoding.encode.call_args_list) == 1
+
+
+def test_special_token_literals_are_encoded_as_plain_text(monkeypatch):
+    class _SpecialTokenEncoding(_CharacterEncoding):
+        def encode(self, text, disallowed_special="all"):
+            if "<|endoftext|>" in text and disallowed_special != ():
+                raise ValueError("disallowed special token")
+            return super().encode(text)
+
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_encoding",
+        _SpecialTokenEncoding(),
+    )
+
+    assert text_token_count("literal <|endoftext|> text") == 26
+    assert truncate_text("<|endoftext|> " * 20, 64).endswith(
+        "\n...[truncated]"
+    )
+
+
+def test_tokenizer_warmup_starts_a_daemon_thread(monkeypatch):
+    thread = Mock()
+    thread_class = Mock(return_value=thread)
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(budget_module.threading, "Thread", thread_class)
+
+    warm_tokenizer_encoding()
+
+    thread_class.assert_called_once_with(
+        target=budget_module._load_tokenizer_encoding,
+        args=(1,),
+        name="nbi-tokenizer-warmup",
+        daemon=True,
+    )
+    thread.start.assert_called_once()
+
+
+def test_tokenizer_thread_start_failure_uses_utf8_fallback(
+    monkeypatch,
+    caplog,
+):
+    thread = Mock()
+    thread.start.side_effect = RuntimeError("thread limit")
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(
+        budget_module.threading,
+        "Thread",
+        Mock(return_value=thread),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = text_token_count("é")
+
+    assert result == 2
+    assert budget_module._tokenizer_load_in_progress is False
+    assert "Could not start the tokenizer warm-up thread" in caplog.text
+
+
+def test_unexpected_budgeting_error_fails_open(monkeypatch, caplog):
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Question " * 500},
+    ]
+    monkeypatch.setattr(
+        budget_module,
+        "estimate_message_tokens",
+        Mock(side_effect=ValueError("malformed message")),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = budget_chat_messages(messages, 128)
+
+    assert result == messages
+    assert "sending the original messages" in caplog.text
+
+
+def test_utf8_fallback_keeps_truncated_history_within_budget(monkeypatch):
+    monkeypatch.setattr(budget_module, "_tokenizer_encoding", None)
+    monkeypatch.setattr(
+        budget_module,
+        "_tokenizer_load_attempts",
+        budget_module._TOKENIZER_MAX_LOAD_ATTEMPTS,
+    )
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "🔥" * 500},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert messages[1] not in result
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_keeps_newest_complete_turns_and_drops_older_turns():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question " * 500},
+        {"role": "assistant", "content": "old answer " * 500},
+        {"role": "user", "content": "recent question"},
+        {"role": "assistant", "content": "recent answer"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    contents = [message["content"] for message in result]
+    assert "old question " * 500 not in contents
+    assert "old answer " * 500 not in contents
+    assert "recent question" in contents
+    assert "recent answer" in contents
+    assert contents[-1] == "current question"
+    assert CONTEXT_OMISSION_NOTICE in contents[0]
+
+
+def test_assistant_only_mcp_prompt_is_prioritized_over_old_history():
+    mcp_prompt = {"role": "assistant", "content": "Return strict JSON."}
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question " * 500},
+        {"role": "assistant", "content": "old answer " * 500},
+        mcp_prompt,
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(
+        messages,
+        128,
+        mcp_prompt_message_count=1,
+    )
+
+    assert mcp_prompt in result
+    assert result[-2:] == [mcp_prompt, messages[-1]]
+    assert messages[1] not in result
+    assert messages[2] not in result
+
+
+def test_multi_message_mcp_prompt_is_kept_as_an_atomic_sequence():
+    mcp_prompt = [
+        {"role": "user", "content": "Use the compact schema."},
+        {"role": "assistant", "content": "Return strict JSON."},
+    ]
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question " * 500},
+        {"role": "assistant", "content": "old answer " * 500},
+        *mcp_prompt,
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(
+        messages,
+        320,
+        mcp_prompt_message_count=2,
+    )
+
+    assert result[-3:] == [*mcp_prompt, messages[-1]]
+    assert messages[1] not in result
+    assert messages[2] not in result
+
+
+def test_current_context_is_prioritized_and_truncated():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "attached context " * 500},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    assert result[-1] == messages[-1]
+    assert result[-2]["role"] == "user"
+    assert result[-2]["content"].endswith(TRUNCATION_MARKER)
+    assert len(result[-2]["content"]) < len(messages[-2]["content"])
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        256 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_newest_current_context_is_selected_before_older_context():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "stale attachment " * 500},
+        {"role": "user", "content": "fresh attachment " * 500},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    contents = [message["content"] for message in result]
+    assert not any(content.startswith("stale") for content in contents)
+    assert any(content.startswith("fresh") for content in contents)
+    assert contents[-1] == "current question"
+
+
+def test_messages_under_budget_are_not_normalized():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "assistant", "content": "orphaned answer"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 4096)
+
+    assert result == messages
+
+
+def test_pruning_drops_an_orphaned_assistant_message():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "assistant", "content": "orphaned answer " * 500},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert [message["role"] for message in result] == ["system", "user"]
+    assert result[-1]["content"] == "current question"
+
+
+def test_tool_call_turn_is_kept_complete_when_history_is_pruned():
+    tool_call = {
+        "id": "call-1",
+        "type": "function",
+        "function": {"name": "inspect_data", "arguments": "{}"},
+    }
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question " * 500},
+        {"role": "assistant", "content": "old answer " * 500},
+        {"role": "user", "content": "inspect the dataframe"},
+        {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+        {"role": "tool", "content": "5 rows", "tool_call_id": "call-1"},
+        {"role": "assistant", "content": "The dataframe has 5 rows."},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 512)
+
+    assert [message["role"] for message in result[1:]] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert result[2]["tool_calls"] == [tool_call]
+    assert result[3]["tool_call_id"] == "call-1"
+
+
+def test_reasoning_content_is_counted_when_history_is_pruned():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question"},
+        {
+            "role": "assistant",
+            "content": "old answer",
+            "reasoning_content": "private reasoning " * 500,
+        },
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert messages[1] not in result
+    assert messages[2] not in result
+    assert result[-1] == messages[-1]
+
+
+def test_incomplete_tool_call_turn_is_dropped_as_a_unit():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "old question " * 500},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-1", "function": {"name": "inspect"}}],
+        },
+        {"role": "tool", "content": "partial result", "tool_call_id": "call-1"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert [message["role"] for message in result] == ["system", "user"]
+    assert result[-1]["content"] == "current question"
+
+
+def test_trailing_tool_message_is_dropped_when_pruning():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-1", "function": {"name": "inspect"}}],
+        },
+        {"role": "user", "content": "current question " * 500},
+        {"role": "tool", "content": "late result", "tool_call_id": "call-1"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert [message["role"] for message in result] == ["system", "user"]
+    assert result[-1]["content"].endswith(TRUNCATION_MARKER)
+
+
+def test_multimodal_context_uses_conservative_image_estimate_and_is_omitted():
+    image_context = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Attached image"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64," + "a" * 10000},
+            },
+        ],
+    }
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        image_context,
+        {"role": "user", "content": "small later context"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    assert image_context not in result
+    assert result[-2]["content"] == "small later context"
+    assert result[-1]["content"] == "current question"
+
+
+def test_image_screening_estimate_is_more_conservative_than_point_estimate():
+    image = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc"},
+    }
+
+    assert budget_module._content_token_screening_estimate(image) > (
+        budget_module._content_token_count(image)
+    )
+
+
+def test_multiple_images_fit_the_conservative_aggregate_bound():
+    image_contexts = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": f"Image {index}"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,image-{index}"
+                    },
+                },
+            ],
+        }
+        for index in range(8)
+    ]
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        *image_contexts,
+        {"role": "user", "content": "Compare the retained images."},
+    ]
+
+    result = budget_chat_messages(messages, 32_768)
+
+    retained_images = sum(
+        1
+        for message in result
+        if isinstance(message.get("content"), list)
+    )
+    assert 0 < retained_images < len(image_contexts)
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        32_768 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+    assert budget_chat_messages(messages, 131_072) == messages
+
+
+def test_oversized_multimodal_request_is_reduced_to_bounded_text():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "mandatory request " * 500},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
+            ],
+        },
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result[-1]["content"][0]["type"] == "text"
+    bounded_text = result[-1]["content"][0]["text"]
+    assert bounded_text.startswith("[Image omitted.]")
+    assert bounded_text.endswith(TRUNCATION_MARKER)
+    assert all(
+        item.get("type") != "image_url"
+        for item in result[-1]["content"]
+    )
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_oversized_image_only_request_gets_a_bounded_text_placeholder():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
+            ],
+        },
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result[-1]["content"] == [
+        {"type": "text", "text": "[Image omitted.]"}
+    ]
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_over_budget_messages_without_a_user_request_keep_bounded_tail(caplog):
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "assistant", "content": "orphaned answer " * 500},
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = budget_chat_messages(messages, 128)
+
+    assert [message["role"] for message in result] == ["system", "assistant"]
+    assert result[0]["content"].startswith(
+        "[Context omitted to fit model window.]"
+    )
+    assert result[-1]["content"].endswith(TRUNCATION_MARKER)
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+    assert "no user request" in caplog.text
+
+
+def test_system_and_latest_user_survive_an_extremely_small_window(caplog):
+    messages = [
+        {"role": "system", "content": "mandatory system instructions"},
+        {"role": "user", "content": "mandatory user request"},
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = budget_chat_messages(messages, 1)
+
+    assert result[0]["content"].startswith("mandatory system instructions")
+    assert result[-1] == messages[-1]
+    assert "Mandatory chat context requires" in caplog.text
+
+
+def test_oversized_latest_user_request_is_truncated_as_last_resort():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "mandatory request " * 500},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert "Context omitted to fit model window" in result[0]["content"]
+    assert result[-1]["content"].endswith(TRUNCATION_MARKER)
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_truncated_latest_user_accounts_for_message_metadata():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {
+            "role": "user",
+            "name": "named-user",
+            "content": "mandatory request " * 500,
+        },
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result[-1]["name"] == "named-user"
+    assert result[-1]["content"].endswith(TRUNCATION_MARKER)
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_text_message_truncation_accounts_for_tool_fields():
+    message = {
+        "role": "assistant",
+        "content": "tool explanation " * 500,
+        "tool_call_id": "call-1",
+        "tool_calls": [
+            {
+                "id": "call-2",
+                "type": "function",
+                "function": {"name": "inspect", "arguments": "{}"},
+            }
+        ],
+    }
+
+    result = budget_module._truncate_text_message(message, 128)
+
+    assert result is not None
+    assert result["tool_call_id"] == "call-1"
+    assert result["tool_calls"] == message["tool_calls"]
+    assert estimate_message_tokens(result) <= 128
+
+
+def test_oversized_system_prompt_is_truncated_to_leave_room_for_user():
+    messages = [
+        {"role": "system", "content": "mandatory system instructions " * 500},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result[0]["role"] == "system"
+    assert result[0]["content"].startswith(
+        "[Context omitted to fit model window.]"
+    )
+    assert result[-1] == messages[-1]
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        128 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_current_context_with_security_delimiters_is_dropped_not_truncated():
+    cell_context = (
+        "Untrusted output:\n<notebook-cell-0123456789abcdef>\n"
+        + "output " * 500
+        + "\n</notebook-cell-0123456789abcdef>"
+    )
+    file_context = (
+        "This file was provided as additional context.\n\n"
+        "File contents:\n```\n"
+        + "file data " * 500
+        + "\n```"
+    )
+    inline_context = (
+        "Generate a replacement for this existing code: ```"
+        + "selected code " * 500
+        + "```"
+    )
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": cell_context},
+        {"role": "user", "content": file_context},
+        {"role": "user", "content": inline_context},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert all(message.get("content") != cell_context for message in result)
+    assert all(message.get("content") != file_context for message in result)
+    assert all(message.get("content") != inline_context for message in result)
+    assert result[-1] == messages[-1]
+
+
+def test_required_inline_edit_context_is_kept_when_old_history_is_pruned():
+    required_context = {
+        "role": "user",
+        "content": (
+            "Generate a replacement for this existing code: ```"
+            "selected = False\n```"
+        ),
+    }
+    messages = [
+        {"role": "system", "content": "Modify the selected code."},
+        {"role": "user", "content": "old question " * 500},
+        {"role": "assistant", "content": "old answer " * 500},
+        required_context,
+        {"role": "user", "content": "Set selected to true."},
+    ]
+
+    result = budget_chat_messages(
+        messages,
+        256,
+        required_context_message_count=1,
+    )
+
+    assert result[-2:] == [required_context, messages[-1]]
+    assert messages[1] not in result
+    assert messages[2] not in result
+
+
+def test_oversized_required_inline_edit_context_fails_open():
+    messages = [
+        {"role": "system", "content": "Modify the selected code."},
+        {
+            "role": "user",
+            "content": (
+                "Generate a replacement for this existing code: ```"
+                + "selected code " * 500
+                + "```"
+            ),
+        },
+        {"role": "user", "content": "Set selected to true."},
+    ]
+
+    result = budget_chat_messages(
+        messages,
+        128,
+        required_context_message_count=1,
+    )
+
+    assert result == messages
+
+
+def test_multiple_system_messages_keep_omission_notice_when_truncated():
+    messages = [
+        {"role": "system", "content": "primary instructions " * 500},
+        {"role": "system", "content": "secondary instructions " * 500},
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    assert result[0]["role"] == "system"
+    assert result[0]["content"].startswith(
+        "[Context omitted to fit model window.]"
+    )
+    assert result[-1] == messages[-1]
+
+
+def test_oversized_protected_guidelines_fail_open_without_cutting_rules():
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "generic prompt\n\n# Additional Guidelines\n"
+                + "mandatory repository rule " * 500
+            ),
+        },
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result == messages
+
+
+def test_protected_guidelines_without_base_prompt_are_not_prefix_truncated():
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "# Additional Guidelines\n"
+                + "mandatory repository rule " * 500
+            ),
+        },
+        {"role": "user", "content": "current question"},
+    ]
+
+    result = budget_chat_messages(messages, 128)
+
+    assert result == messages
+
+
+def test_short_system_notice_survives_final_mandatory_context_fallback():
+    messages = [
+        {"role": "system", "content": "mandatory instructions " * 500},
+        {
+            "role": "user",
+            "name": "n" * 80,
+            "content": "mandatory request " * 500,
+        },
+    ]
+
+    result = budget_chat_messages(messages, 256)
+
+    assert result[0] == {
+        "role": "system",
+        "content": "[Context omitted to fit model window.]",
+    }
+    assert result[-1]["content"].endswith(TRUNCATION_MARKER)
+    assert sum(estimate_message_tokens(message) for message in result) <= int(
+        256 * CHAT_INPUT_BUDGET_RATIO
+    )
+
+
+def test_invalid_context_window_leaves_messages_unchanged():
+    messages = [{"role": "user", "content": "Question"}]
+
+    assert budget_chat_messages(messages, 0) == messages
+    assert budget_chat_messages(messages, "4096") == messages

--- a/tests/test_github_copilot_llm_provider.py
+++ b/tests/test_github_copilot_llm_provider.py
@@ -3,6 +3,9 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from notebook_intelligence import github_copilot as gh_copilot
+from notebook_intelligence.base_chat_participant import (
+    _chat_history_context_window,
+)
 from notebook_intelligence.llm_providers.github_copilot_llm_provider import GitHubCopilotLLMProvider
 
 
@@ -27,6 +30,10 @@ def test_chat_models_include_recent_github_copilot_models():
     assert models["gemini-3.1-pro"].name == "Gemini 3.1 Pro"
 
     assert all(model.supports_tools for model in models.values())
+    assert all(
+        model.context_window_is_configured is False
+        for model in models.values()
+    )
 
 
 def test_chat_models_use_dynamic_cache_when_populated():
@@ -70,7 +77,11 @@ def test_fetch_copilot_models_floors_zero_context_window_to_default():
         "id": "no-limits-model",
         "name": "No Limits",
         "context_window": 4096,
+        "context_window_is_configured": False,
     }]
+    model = GitHubCopilotLLMProvider().chat_models[0]
+    assert model.context_window_is_configured is False
+    assert _chat_history_context_window(model) == 0
 
 
 def test_fetch_copilot_models_preserves_cache_on_empty_response():
@@ -156,6 +167,8 @@ def test_fetch_copilot_models_filters_to_picker_enabled_chat_models():
     assert [m["id"] for m in result] == ["gpt-foo", "claude-bar"]
     assert result[0]["context_window"] == 64000
     assert result[1]["context_window"] == 128000
+    assert result[0]["context_window_is_configured"] is True
+    assert result[1]["context_window_is_configured"] is True
     # Falls back to id when name is missing.
     assert result[1]["name"] == "claude-bar"
 

--- a/tests/test_litellm_compatible_llm_provider.py
+++ b/tests/test_litellm_compatible_llm_provider.py
@@ -1,0 +1,20 @@
+from notebook_intelligence.base_chat_participant import (
+    _chat_history_context_window,
+)
+from notebook_intelligence.llm_providers.litellm_compatible_llm_provider import (
+    DEFAULT_CONTEXT_WINDOW,
+    LiteLLMCompatibleLLMProvider,
+)
+
+
+def test_blank_context_window_does_not_trigger_history_pruning():
+    model = LiteLLMCompatibleLLMProvider().chat_models[0]
+
+    assert model.context_window == DEFAULT_CONTEXT_WINDOW
+    assert model.context_window_is_configured is False
+    assert _chat_history_context_window(model) == 0
+
+    model.set_property_value("context_window", "32768")
+
+    assert model.context_window_is_configured is True
+    assert _chat_history_context_window(model) == 32768

--- a/tests/test_openai_compatible_llm_provider.py
+++ b/tests/test_openai_compatible_llm_provider.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock, patch
 
+from notebook_intelligence.base_chat_participant import (
+    _chat_history_context_window,
+)
 from notebook_intelligence.llm_providers.openai_compatible_llm_provider import (
+    DEFAULT_CONTEXT_WINDOW,
     OpenAICompatibleLLMProvider,
     sanitize_tools_for_openai_compatible,
 )
@@ -23,6 +27,19 @@ def test_sanitize_tools_for_openai_compatible_removes_function_strict_without_mu
 
     assert sanitized[0]["function"].get("strict") is None
     assert tools[0]["function"]["strict"] is True
+
+
+def test_blank_context_window_does_not_trigger_history_pruning():
+    model = OpenAICompatibleLLMProvider().chat_models[0]
+
+    assert model.context_window == DEFAULT_CONTEXT_WINDOW
+    assert model.context_window_is_configured is False
+    assert _chat_history_context_window(model) == 0
+
+    model.set_property_value("context_window", "65536")
+
+    assert model.context_window_is_configured is True
+    assert _chat_history_context_window(model) == 65536
 
 
 @patch("openai.OpenAI")

--- a/tests/test_rule_injector.py
+++ b/tests/test_rule_injector.py
@@ -1,7 +1,9 @@
 from unittest.mock import Mock, patch
 
+import notebook_intelligence.chat_history_budget as budget_module
 from notebook_intelligence.api import ChatRequest
-from notebook_intelligence.rule_injector import RuleInjector, _TOKEN_ENCODING
+from notebook_intelligence.chat_history_budget import text_token_count
+from notebook_intelligence.rule_injector import RuleInjector
 from notebook_intelligence.ruleset import Rule, RuleContext
 
 
@@ -123,7 +125,12 @@ class TestRuleInjector:
 
         assert result == "BASE"
 
-    def test_token_budget_truncates_additional_guidelines(self):
+    def test_token_budget_truncates_additional_guidelines(self, monkeypatch):
+        monkeypatch.setattr(
+            budget_module,
+            "_tokenizer_encoding",
+            budget_module.tiktoken.encoding_for_model("gpt-4o"),
+        )
         injector = RuleInjector()
         request = Mock(spec=ChatRequest)
         request.rule_context = Mock(spec=RuleContext)
@@ -137,7 +144,7 @@ class TestRuleInjector:
 
         assert result.startswith("BASE\n\n# Additional Guidelines")
         assert result.endswith("...[additional guidelines truncated]")
-        assert len(_TOKEN_ENCODING.encode(result)) <= 30
+        assert text_token_count(result) <= 30
 
     def test_inject_rules_with_agents_md_only(self, tmp_path):
         injector = RuleInjector()

--- a/tests/test_websocket_handler_integration.py
+++ b/tests/test_websocket_handler_integration.py
@@ -6,7 +6,12 @@ import json
 from unittest.mock import Mock, patch, MagicMock
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application
-from notebook_intelligence.extension import WebsocketCopilotHandler
+from notebook_intelligence.extension import (
+    NotebookIntelligence,
+    WebsocketCopilotHandler,
+    _token_count,
+    _truncate_context_content,
+)
 from notebook_intelligence.api import ChatResponse
 from notebook_intelligence.claude import ClaudeCodeChatParticipant
 from notebook_intelligence.context_factory import RuleContextFactory
@@ -16,6 +21,33 @@ from notebook_intelligence.ruleset import RuleContext
 
 
 class TestWebsocketHandlerIntegration:
+    def test_initialize_settings_warms_tokenizer(self):
+        with patch(
+            "notebook_intelligence.extension.warm_tokenizer_encoding"
+        ) as warm_tokenizer:
+            NotebookIntelligence.initialize_settings(Mock())
+
+        warm_tokenizer.assert_called_once_with()
+
+    def test_context_budget_helpers_use_strict_shared_token_policy(self):
+        encoding = Mock()
+        encoding.encode.side_effect = lambda text, **_kwargs: list(
+            text.encode("utf-8")
+        )
+        encoding.decode.side_effect = lambda tokens: bytes(tokens).decode(
+            "utf-8", errors="ignore"
+        )
+        with patch(
+            "notebook_intelligence.chat_history_budget._get_encoding",
+            return_value=encoding,
+        ):
+            assert _token_count("shared token counter") > 0
+            assert _truncate_context_content("large context " * 100, 1) == ""
+
+            truncated = _truncate_context_content("large context " * 100, 16)
+            assert truncated.endswith("\n...[truncated]")
+            assert _token_count(truncated) <= 16
+
     def _create_mock_application(self):
         """Create a properly mocked Tornado Application.
 
@@ -180,6 +212,8 @@ class TestWebsocketHandlerIntegration:
         chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
         assert chat_request.language == 'python'
         assert chat_request.kernel_name == 'python3'
+        assert chat_request.prompt == "Generate code for: Generate some code"
+        assert chat_request.required_context_message_count == 0
 
         options = mock_ai_manager.handle_chat_request.call_args.kwargs['options']
         assert options['system_prompt'] == (
@@ -222,6 +256,15 @@ class TestWebsocketHandlerIntegration:
         sdk_client.messages.stream.return_value = Stream()
 
         async def dispatch(request, response, options=None):
+            assert request.required_context_message_count == 1
+            assert request.chat_history[-1]["content"].startswith(
+                "You are asked to modify the existing code."
+            )
+            # Mirror AIServiceManager, which appends the parsed final prompt
+            # before dispatching to the selected participant.
+            request.chat_history.append(
+                {"role": "user", "content": request.prompt}
+            )
             request.host = manager
             await participant.handle_chat_request(
                 request,


### PR DESCRIPTION
## Summary

- budget ask-mode and built-in generation messages against 80% of the active model context window
- preserve system guidance, injected rules, required inline-edit source, MCP prompt sequences, and the newest request without splitting tool-call turns
- truncate safe text context, omit protected fenced or multimodal context atomically, and include omission notices
- load tokenization asynchronously with bounded retries and conservative fallbacks
- skip pruning when a provider context window is inferred rather than configured; agent tool loops remain unchanged

## Validation

- 1,619 tests passed
- focused chat-history, dispatch, inline-edit, rules, and provider regression suites passed
- Cora approved exact commit 6cc3599b with both Codex and Claude
- one squashed Angular-style commit
- fork-only review workflows and scripts are excluded