### PR TITLE
fix(acp): stop serving client file reads and writes to ACP agents

### DIFF
--- a/notebook_intelligence/acp_agent.py
+++ b/notebook_intelligence/acp_agent.py
@@ -231,17 +231,15 @@ class _NbiAcpClient(acp.Client):
         return acp.RequestPermissionResponse(outcome=schema.DeniedOutcome(outcome="cancelled"))
 
     # fs/*: not offered. These would run in the Jupyter server process, outside
-    # any agent sandbox, so an agent that delegated file I/O here could escape
-    # its own sandbox, for example by swapping a path for a symlink between a
-    # containment check and the write. Agents do their own file I/O instead:
-    # codex-acp always does, and claude-code-acp keeps its own file tools when
-    # the capability is not advertised. The acp router registers these handlers
-    # whatever NBI advertises, so they must refuse rather than go unused.
+    # any agent sandbox, so serving them would let an agent read or write any
+    # path the server can reach. The spec requires an agent to do its own file
+    # I/O when the capability is not advertised. The acp router registers these
+    # handlers whatever NBI advertises, so they must refuse rather than go unused.
     async def read_text_file(self, path, session_id, limit=None, line=None, **kw):
-        raise acp.RequestError.method_not_found("fs not supported")
+        raise acp.RequestError.method_not_found("fs/read_text_file")
 
     async def write_text_file(self, content, path, session_id, **kw):
-        raise acp.RequestError.method_not_found("fs not supported")
+        raise acp.RequestError.method_not_found("fs/write_text_file")
 
     # terminal/*: not emulated in Phase 1 (Codex runs shell internally).
     async def create_terminal(self, command, session_id, **kw):
@@ -258,6 +256,11 @@ class _NbiAcpClient(acp.Client):
 
     async def release_terminal(self, session_id, terminal_id, **kw):
         return None
+
+    # The inherited acp.Client stub answers any extension request with a null
+    # success, which an agent would read as "handled".
+    async def ext_method(self, method, params):
+        raise acp.RequestError.method_not_found(method)
 
 
 def _block_text(block) -> str:

--- a/notebook_intelligence/acp_agent.py
+++ b/notebook_intelligence/acp_agent.py
@@ -230,23 +230,18 @@ class _NbiAcpClient(acp.Client):
             )
         return acp.RequestPermissionResponse(outcome=schema.DeniedOutcome(outcome="cancelled"))
 
-    # fs/*: implemented so an agent that delegates file ops (e.g. claude-acp)
-    # routes through NBI. codex-acp self-applies, so these may not fire for it.
+    # fs/*: not offered. These would run in the Jupyter server process, outside
+    # any agent sandbox, so an agent that delegated file I/O here could escape
+    # its own sandbox, for example by swapping a path for a symlink between a
+    # containment check and the write. Agents do their own file I/O instead:
+    # codex-acp always does, and claude-code-acp keeps its own file tools when
+    # the capability is not advertised. The acp router registers these handlers
+    # whatever NBI advertises, so they must refuse rather than go unused.
     async def read_text_file(self, path, session_id, limit=None, line=None, **kw):
-        try:
-            with open(path, encoding="utf-8") as f:
-                return acp.ReadTextFileResponse(content=f.read())
-        except Exception as e:
-            raise acp.RequestError.internal_error(str(e))
+        raise acp.RequestError.method_not_found("fs not supported")
 
     async def write_text_file(self, content, path, session_id, **kw):
-        try:
-            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(content)
-            return acp.WriteTextFileResponse()
-        except Exception as e:
-            raise acp.RequestError.internal_error(str(e))
+        raise acp.RequestError.method_not_found("fs not supported")
 
     # terminal/*: not emulated in Phase 1 (Codex runs shell internally).
     async def create_terminal(self, command, session_id, **kw):
@@ -439,7 +434,7 @@ class AcpAgentClient:
             init = await self._conn.initialize(
                 protocol_version=acp.PROTOCOL_VERSION,
                 client_capabilities=schema.ClientCapabilities(
-                    fs=schema.FileSystemCapabilities(read_text_file=True, write_text_file=True),
+                    fs=schema.FileSystemCapabilities(read_text_file=False, write_text_file=False),
                 ),
                 client_info=schema.Implementation(name="notebook-intelligence", version="1.0.0"),
             )

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -322,37 +322,78 @@ class TestClientFileSystemNotOffered:
     """NBI does not serve ``fs/read_text_file`` or ``fs/write_text_file``.
 
     They would run in the Jupyter server process, outside any agent sandbox,
-    so a delegating agent could use them to escape its own sandbox. The acp
-    router registers the handlers regardless of the advertised capability, so
-    both the advertisement and the handlers themselves are pinned."""
+    so a delegating agent could reach any path the server can. The acp router
+    registers the handlers regardless of the advertised capability, so the
+    advertisement, the handlers, and the router's answer are all pinned."""
 
     @staticmethod
-    def _client():
-        return _client_with_response(None)
+    def _snapshot(root):
+        return {p: (p.read_bytes() if p.is_file() else None) for p in root.rglob("*")}
 
-    def test_read_is_refused_without_touching_the_file(self, tmp_path):
-        target = tmp_path / "notes.txt"
-        target.write_text("SECRET-CONTENT-7F3A", encoding="utf-8")
+    @pytest.mark.parametrize("layout", ["missing_parent", "existing_parent", "existing_file"])
+    def test_write_is_refused_and_leaves_the_disk_unchanged(self, tmp_path, layout):
+        (tmp_path / "existing").mkdir()
+        if layout == "missing_parent":
+            target = tmp_path / "new" / "planted.txt"
+        elif layout == "existing_parent":
+            target = tmp_path / "existing" / "planted.txt"
+        else:
+            target = tmp_path / "existing" / "kept.txt"
+            target.write_text("ORIGINAL", encoding="utf-8")
+        before = self._snapshot(tmp_path)
 
         with pytest.raises(acp.RequestError) as excinfo:
-            asyncio.run(self._client().read_text_file(path=str(target), session_id="s"))
-
-        assert excinfo.value.to_error_obj()["code"] == -32601
-
-    def test_write_is_refused_without_creating_the_file(self, tmp_path):
-        target = tmp_path / "new" / "planted.txt"
-
-        with pytest.raises(acp.RequestError) as excinfo:
-            asyncio.run(self._client().write_text_file(
+            asyncio.run(_client_with_response(None).write_text_file(
                 content="planted", path=str(target), session_id="s",
             ))
 
         assert excinfo.value.to_error_obj()["code"] == -32601
-        assert not (tmp_path / "new").exists()
+        assert self._snapshot(tmp_path) == before
+
+    def test_read_is_refused_without_returning_the_file(self, tmp_path):
+        target = tmp_path / "notes.txt"
+        target.write_text("SECRET-CONTENT-7F3A", encoding="utf-8")
+
+        with pytest.raises(acp.RequestError) as excinfo:
+            asyncio.run(_client_with_response(None).read_text_file(
+                path=str(target), session_id="s",
+            ))
+
+        error = excinfo.value.to_error_obj()
+        assert error["code"] == -32601
+        assert "SECRET-CONTENT-7F3A" not in repr(error)
+
+    @pytest.mark.parametrize("method,params", [
+        ("fs/read_text_file", {"sessionId": "s", "line": 1, "limit": 5}),
+        ("fs/write_text_file", {"sessionId": "s", "content": "planted"}),
+        ("_nbi/unknown", {}),
+    ])
+    def test_router_answers_method_not_found(self, tmp_path, method, params):
+        """Pin the answer at the protocol boundary, where the router maps
+        request params onto the handler's arguments."""
+        from acp.client.router import build_client_router
+
+        target = tmp_path / "planted.txt"
+        if method.startswith("fs/"):
+            params = {**params, "path": str(target)}
+        router = build_client_router(_client_with_response(None))
+
+        with pytest.raises(acp.RequestError) as excinfo:
+            asyncio.run(router(method, params, False))
+
+        assert excinfo.value.to_error_obj()["code"] == -32601
+        assert not target.exists()
 
     def test_initialize_does_not_advertise_fs(self, tmp_path, monkeypatch):
+        import inspect
+
+        from acp.client.connection import ClientSideConnection
+
         import notebook_intelligence.acp_agent as mod
 
+        # A missed patch must fail fast rather than launch a real agent.
+        monkeypatch.setenv("NBI_ACP_AGENT_COMMAND", "nbi-test-must-not-spawn")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         captured = {}
 
         class FakeProc:
@@ -370,8 +411,14 @@ class TestClientFileSystemNotOffered:
             return FakeProc()
 
         class FakeConn:
-            async def initialize(self, **kw):
-                captured["capabilities"] = kw["client_capabilities"]
+            async def initialize(self, *args, **kwargs):
+                bound = inspect.signature(ClientSideConnection.initialize).bind(
+                    self, *args, **kwargs
+                )
+                captured["capabilities"] = (
+                    bound.arguments.get("client_capabilities")
+                    or schema.ClientCapabilities()
+                )
                 raise RuntimeError("test: capabilities captured, session not started")
 
         monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
@@ -386,6 +433,9 @@ class TestClientFileSystemNotOffered:
 
         asyncio.run(client._serve())
 
+        assert "capabilities" in captured, (
+            f"_serve never reached initialize: {client._start_error}"
+        )
         fs = captured["capabilities"].fs
         assert fs.read_text_file is False
         assert fs.write_text_file is False

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import acp
 from acp import schema
 
 from notebook_intelligence.acp_agent import (
@@ -315,6 +316,79 @@ class TestCodexModelArgs:
             "-c", 'model="m1"',
             "-c", 'openai_base_url="http://proxy/v1"',
         ]
+
+
+class TestClientFileSystemNotOffered:
+    """NBI does not serve ``fs/read_text_file`` or ``fs/write_text_file``.
+
+    They would run in the Jupyter server process, outside any agent sandbox,
+    so a delegating agent could use them to escape its own sandbox. The acp
+    router registers the handlers regardless of the advertised capability, so
+    both the advertisement and the handlers themselves are pinned."""
+
+    @staticmethod
+    def _client():
+        return _client_with_response(None)
+
+    def test_read_is_refused_without_touching_the_file(self, tmp_path):
+        target = tmp_path / "notes.txt"
+        target.write_text("SECRET-CONTENT-7F3A", encoding="utf-8")
+
+        with pytest.raises(acp.RequestError) as excinfo:
+            asyncio.run(self._client().read_text_file(path=str(target), session_id="s"))
+
+        assert excinfo.value.to_error_obj()["code"] == -32601
+
+    def test_write_is_refused_without_creating_the_file(self, tmp_path):
+        target = tmp_path / "new" / "planted.txt"
+
+        with pytest.raises(acp.RequestError) as excinfo:
+            asyncio.run(self._client().write_text_file(
+                content="planted", path=str(target), session_id="s",
+            ))
+
+        assert excinfo.value.to_error_obj()["code"] == -32601
+        assert not (tmp_path / "new").exists()
+
+    def test_initialize_does_not_advertise_fs(self, tmp_path, monkeypatch):
+        import notebook_intelligence.acp_agent as mod
+
+        captured = {}
+
+        class FakeProc:
+            stdin = stdout = object()
+            stderr = None
+            returncode = None
+
+            def terminate(self):
+                self.returncode = 0
+
+            async def wait(self):
+                return 0
+
+        async def fake_exec(*cmd, **kw):
+            return FakeProc()
+
+        class FakeConn:
+            async def initialize(self, **kw):
+                captured["capabilities"] = kw["client_capabilities"]
+                raise RuntimeError("test: capabilities captured, session not started")
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(mod.acp, "connect_to_agent", lambda *a, **k: FakeConn())
+        client = mod.AcpAgentClient(SimpleNamespace(
+            websocket_connector=None,
+            nbi_config=SimpleNamespace(
+                acp_settings={"enabled": True, "agent": "codex"},
+                nbi_user_dir=str(tmp_path),
+            ),
+        ))
+
+        asyncio.run(client._serve())
+
+        fs = captured["capabilities"].fs
+        assert fs.read_text_file is False
+        assert fs.write_text_file is False
 
 
 class TestAssembleQuery:


### PR DESCRIPTION
## Summary

NBI's ACP client advertised the fs capability (`FileSystemCapabilities(read_text_file=True, write_text_file=True)`) and served `fs/read_text_file` and `fs/write_text_file` by opening whatever path the agent sent, from the Jupyter server process. That process runs outside any agent sandbox. An agent that delegates file I/O to the client could therefore read or write any path the server's account can reach, with no workspace containment and no approval. The pinned `codex-acp` 0.16.0 never calls these methods, so nothing is exploitable with the default agent today. The exposure is for any agent that does delegate. For example, claude-code-acp 0.16.2, launched through `NBI_ACP_AGENT_COMMAND`, turns off its own Read, Write, and Edit tools when the capability is advertised and routes them here, and it auto-approves the read tool.

## Solution

**Stop offering the capability.** `initialize` now advertises no fs support, and both handlers raise `method_not_found` (naming the refused method), matching the existing `terminal/*` refusals. The ACP spec requires an agent to do its own file I/O when the capability is not advertised, so delegating agents keep working. Their file access now runs in their own process, inside their own sandbox, under their own permission engine.

**Why the handlers refuse rather than being removed.** The acp router registers both routes whatever the client advertises (`acp/client/router.py`). `_NbiAcpClient` subclasses the `acp.Client` Protocol, whose stubs would answer a non-compliant agent with a `null` success. For the same reason, `ext_method` now refuses extension requests instead of inheriting that stub.

**Why not contain the handlers instead.** I tried confining both handlers to the workspace with `safe_jupyter_path` first. Review showed that containment in the server process does not hold:
- **Symlink race:** a symlink swap between the check and the write escaped the workspace. It was reproduced against the real handler from inside a Codex-style macOS sandbox.
- **Hardlinks:** a write through a hardlink changed a file outside the workspace.
- **Truncation:** opening with `"w"` empties the file before a failing write.
- **FIFOs:** a FIFO read hung the ACP session.

A race-free `openat`-style helper is possible, but no supported agent needs the capability, and ACP v2 removes client fs entirely.

## Testing

**Automated** (`TestClientFileSystemNotOffered`):
- A refused write leaves the disk byte-for-byte unchanged, whether the parent directory is missing, exists, or already holds a file.
- A refused read does not return the file's content.
- `fs/read_text_file`, `fs/write_text_file`, and an unknown `_` extension method each answer -32601 through the real `build_client_router`, where request params are mapped onto the handler.
- `initialize` does not advertise fs. The capture fails with a clear message if `_serve` aborts early, and it cannot launch a real agent if its patch is ever missed.
- All 8 cases fail against `upstream/main`'s `acp_agent.py` and pass with this change.

**Suite:** `pytest tests/ --ignore=tests/test_claude_client.py` gives 1761 passed. `jlpm tsc --noEmit`, stylelint, prettier, and eslint are clean, and `jlpm jest` gives 423 passed.

**Interop, checked against source:**
- `codex-acp` 0.16.0 only sends `session/update` and `session/request_permission`.
- claude-code-acp registers its fs-routed tools only when the capability is advertised. Every tag checked from v0.1.6 through v0.17.0 gates on it, and later versions do not use client fs at all.
- A refused call from a non-compliant agent leaves the connection usable.

No live JupyterLab run: the change has no UI, and the router-level tests exercise the protocol path.

## Risks / follow-ups

- **Behavior change for delegating agents.** An agent launched through `NBI_ACP_AGENT_COMMAND` that relied on client fs now uses its own file tools. For claude-code-acp that is stricter: its built-in writes still go through permission prompts, and its read tool is no longer auto-approved to reach any path.
- **Error `data` in terminal refusals.** The existing `terminal/*` refusals pass `"terminal not supported"` where `method_not_found` expects a method name. I left those lines alone; they could be aligned separately.
- **Log noise.** Each refused request logs a "Background task failed" traceback via the acp library, as unknown methods and terminal refusals already do.
- **Built-in file tools.** The same check-then-open race exists in NBI's built-in file tools (for example `write_to_file`). There the model's own shell is not sandboxed, so the gate guards against mistakes rather than enforcing a boundary. That may still be worth a separate look.
- **Pre-existing flaky test.** `tests/test_perf.py::TestSpanNesting::test_spans_carry_ids_that_reconstruct_the_tree` is order-dependent and fails in some test orders independent of this change.

No issue was filed for this. The analysis is in the Summary and Solution.
