### PR TITLE
fix(acp): show a useful label in the ACP session picker

### DIFF
--- a/notebook_intelligence/acp_agent.py
+++ b/notebook_intelligence/acp_agent.py
@@ -291,7 +291,7 @@ def _epoch_from_iso(value) -> float:
 _POINTER_VALUE = r"[^']*(?:'|\Z)"
 _CONTEXT_POINTER = re.compile(
     re.escape(NBI_CONTEXT_PREFIX)
-    + r" '" + _POINTER_VALUE
+    + r" '(?P<dir>[^']*)(?:'|\Z)"
     + r"(?: and current file is: '(?P<file>[^']*)(?:'|\Z))?"
     + r"(?: and active programming language is: '" + _POINTER_VALUE + ")?"
     + r"(?: with active kernel name: '" + _POINTER_VALUE
@@ -319,10 +319,12 @@ def _strip_context_preamble(title: str) -> str:
     directory pointer is matched structurally by its quoted segments. A
     pointer naming a file and a language is already longer than the agents'
     title limit, so a truncated title usually ends inside the pointer. When
-    nothing of the question is left, the preview names the current file (cut
-    short with the agent's marker if the title ended inside it), or is empty
-    if the title ended before the file. An untruncated title that holds only
-    context keeps the title as before.
+    nothing of the question is left, the preview names the current file,
+    relative to the open directory and cut short with the agent's marker if
+    the title ended inside it. If the cut left none of the file's own name, or
+    came before any file, the preview names the directory when the title holds
+    all of it, and is empty otherwise. A title with no file and no question
+    that was not truncated is kept as before.
     """
     lines = [line for line in title.splitlines() if line.strip()]
     while lines and (
@@ -347,12 +349,23 @@ def _strip_context_preamble(title: str) -> str:
     remainder = (title[:pointer.start()] + rest.lstrip()).strip()
     if remainder:
         return remainder
+    directory = pointer.group("dir")
     file = pointer.group("file")
-    if file and marker and pointer.end("file") == len(body):
-        return file + marker
-    if file:
-        return file
-    return "" if marker else title
+    if not file:
+        if not marker:
+            return title
+        return directory if pointer.end("dir") < len(body) else ""
+    file_cut = bool(marker) and pointer.end("file") == len(body)
+    # The file path starts from the Jupyter root and usually repeats the
+    # open directory, which would otherwise use up the whole preview.
+    inside = f"{directory}/" if directory else ""
+    if inside and file.startswith(inside):
+        file = file[len(inside):]
+    elif inside and file_cut and inside.startswith(file):
+        file = ""
+    if not file:
+        return directory
+    return file + marker if file_cut else file
 
 
 def _diffs_from_content(content) -> list[dict]:

--- a/notebook_intelligence/acp_agent.py
+++ b/notebook_intelligence/acp_agent.py
@@ -58,7 +58,7 @@ from notebook_intelligence.acp_registry import (
     resolve_acp_agent_command,
 )
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
-from notebook_intelligence.claude_sessions import CONTROL_SLASH_COMMANDS
+from notebook_intelligence.claude_sessions import CONTROL_SLASH_COMMANDS, NBI_CONTEXT_PREFIX
 from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
@@ -283,6 +283,38 @@ def _epoch_from_iso(value) -> float:
         return 0
 
 
+# The directory pointer extension.py puts before every agent-mode prompt. Each
+# segment after the directory is optional, and the kernel display name only
+# follows the kernel name. A display name may hold one level of parentheses,
+# as in "Python 3 (ipykernel)".
+_CONTEXT_POINTER = re.compile(
+    re.escape(NBI_CONTEXT_PREFIX)
+    + r" '[^']*'"
+    + r"(?: and current file is: '(?P<file>[^']*)')?"
+    + r"(?: and active programming language is: '[^']*')?"
+    + r"(?P<kernel> with active kernel name: '[^']*'"
+    + r"(?: \((?:[^()]|\([^()]*\))*\))?)?"
+)
+_CONTEXT_POINTER_SEGMENTS = (
+    " and current file is: '",
+    " and active programming language is: '",
+    " with active kernel name: '",
+)
+# codex-acp cuts a session title at 117 characters and appends this marker.
+_TITLE_TRUNCATION_MARKER = "..."
+
+
+def _is_cut_pointer_segment(tail: str, after_kernel: bool) -> bool:
+    """True when ``tail`` (the title after the pointer's complete segments,
+    truncation marker removed) is the start of one more pointer segment."""
+    for segment in _CONTEXT_POINTER_SEGMENTS:
+        if segment.startswith(tail):
+            return True
+        if tail.startswith(segment) and "'" not in tail[len(segment):]:
+            return True
+    return after_kernel and tail.startswith(" (") and tail.count("(") > tail.count(")")
+
+
 def _strip_context_preamble(title: str) -> str:
     """Drop NBI's leading context lines from an agent-stored session title.
 
@@ -292,9 +324,12 @@ def _strip_context_preamble(title: str) -> str:
 
     Handles both shapes: newline-separated lines, and the joined form codex
     stores (newlines collapsed to spaces, title truncated), where the
-    directory pointer is matched structurally by its quoted segments.
+    directory pointer is matched structurally by its quoted segments. Codex
+    truncates titles at 117 characters, which a pointer naming a file,
+    language, and kernel already fills. When nothing of the question is left,
+    the preview names the current file instead, or keeps the title if the
+    pointer has none.
     """
-    from notebook_intelligence.claude_sessions import NBI_CONTEXT_PREFIX
     lines = [line for line in title.splitlines() if line.strip()]
     while lines and (
         lines[0].startswith(NBI_CONTEXT_PREFIX)
@@ -304,13 +339,17 @@ def _strip_context_preamble(title: str) -> str:
     stripped = " ".join(lines)
     if stripped and stripped != title.strip():
         return stripped
-    # Joined form: peel the directory pointer off the front by shape.
-    joined_preamble = re.compile(
-        re.escape(NBI_CONTEXT_PREFIX)
-        + r" '[^']*'( and current file is: '[^']*')?\s*"
-    )
-    remainder = joined_preamble.sub("", title, count=1)
-    return remainder.strip() or title
+    # Joined form: peel the directory pointer off by shape.
+    pointer = _CONTEXT_POINTER.search(title)
+    if pointer is None:
+        return title
+    rest = title[pointer.end():]
+    if rest.endswith(_TITLE_TRUNCATION_MARKER) and _is_cut_pointer_segment(
+        rest[: -len(_TITLE_TRUNCATION_MARKER)], pointer.group("kernel") is not None
+    ):
+        rest = ""
+    remainder = (title[:pointer.start()] + rest.lstrip()).strip()
+    return remainder or pointer.group("file") or title
 
 
 def _diffs_from_content(content) -> list[dict]:

--- a/notebook_intelligence/acp_agent.py
+++ b/notebook_intelligence/acp_agent.py
@@ -286,33 +286,25 @@ def _epoch_from_iso(value) -> float:
 # The directory pointer extension.py puts before every agent-mode prompt. Each
 # segment after the directory is optional, and the kernel display name only
 # follows the kernel name. A display name may hold one level of parentheses,
-# as in "Python 3 (ipykernel)".
+# as in "Python 3 (ipykernel)". A value or display name may also run to the
+# end without closing, where an agent truncated the title inside it.
+_POINTER_VALUE = r"[^']*(?:'|\Z)"
 _CONTEXT_POINTER = re.compile(
     re.escape(NBI_CONTEXT_PREFIX)
-    + r" '[^']*'"
-    + r"(?: and current file is: '(?P<file>[^']*)')?"
-    + r"(?: and active programming language is: '[^']*')?"
-    + r"(?P<kernel> with active kernel name: '[^']*'"
-    + r"(?: \((?:[^()]|\([^()]*\))*\))?)?"
+    + r" '" + _POINTER_VALUE
+    + r"(?: and current file is: '(?P<file>[^']*)(?:'|\Z))?"
+    + r"(?: and active programming language is: '" + _POINTER_VALUE + ")?"
+    + r"(?: with active kernel name: '" + _POINTER_VALUE
+    + r"(?: \((?:[^()]|\([^()]*(?:\)|\Z))*(?:\)|\Z))?)?"
 )
 _CONTEXT_POINTER_SEGMENTS = (
     " and current file is: '",
     " and active programming language is: '",
     " with active kernel name: '",
 )
-# codex-acp cuts a session title at 117 characters and appends this marker.
-_TITLE_TRUNCATION_MARKER = "..."
-
-
-def _is_cut_pointer_segment(tail: str, after_kernel: bool) -> bool:
-    """True when ``tail`` (the title after the pointer's complete segments,
-    truncation marker removed) is the start of one more pointer segment."""
-    for segment in _CONTEXT_POINTER_SEGMENTS:
-        if segment.startswith(tail):
-            return True
-        if tail.startswith(segment) and "'" not in tail[len(segment):]:
-            return True
-    return after_kernel and tail.startswith(" (") and tail.count("(") > tail.count(")")
+# Markers the agents append to a truncated session title: codex-acp cuts at
+# 117 characters plus "...", claude-code-acp at 127 plus a single ellipsis.
+_TITLE_TRUNCATION_MARKERS = ("...", "\u2026")
 
 
 def _strip_context_preamble(title: str) -> str:
@@ -324,11 +316,13 @@ def _strip_context_preamble(title: str) -> str:
 
     Handles both shapes: newline-separated lines, and the joined form codex
     stores (newlines collapsed to spaces, title truncated), where the
-    directory pointer is matched structurally by its quoted segments. Codex
-    truncates titles at 117 characters, which a pointer naming a file,
-    language, and kernel already fills. When nothing of the question is left,
-    the preview names the current file instead, or keeps the title if the
-    pointer has none.
+    directory pointer is matched structurally by its quoted segments. A
+    pointer naming a file and a language is already longer than the agents'
+    title limit, so a truncated title usually ends inside the pointer. When
+    nothing of the question is left, the preview names the current file (cut
+    short with the agent's marker if the title ended inside it), or is empty
+    if the title ended before the file. An untruncated title that holds only
+    context keeps the title as before.
     """
     lines = [line for line in title.splitlines() if line.strip()]
     while lines and (
@@ -340,16 +334,25 @@ def _strip_context_preamble(title: str) -> str:
     if stripped and stripped != title.strip():
         return stripped
     # Joined form: peel the directory pointer off by shape.
-    pointer = _CONTEXT_POINTER.search(title)
+    marker = next((m for m in _TITLE_TRUNCATION_MARKERS if title.endswith(m)), "")
+    body = title[: len(title) - len(marker)]
+    pointer = _CONTEXT_POINTER.search(body)
     if pointer is None:
         return title
     rest = title[pointer.end():]
-    if rest.endswith(_TITLE_TRUNCATION_MARKER) and _is_cut_pointer_segment(
-        rest[: -len(_TITLE_TRUNCATION_MARKER)], pointer.group("kernel") is not None
-    ):
+    tail = body[pointer.end():]
+    if marker and any(segment.startswith(tail) for segment in _CONTEXT_POINTER_SEGMENTS):
+        # The title ended inside the pointer: nothing after it is the question.
         rest = ""
     remainder = (title[:pointer.start()] + rest.lstrip()).strip()
-    return remainder or pointer.group("file") or title
+    if remainder:
+        return remainder
+    file = pointer.group("file")
+    if file and marker and pointer.end("file") == len(body):
+        return file + marker
+    if file:
+        return file
+    return "" if marker else title
 
 
 def _diffs_from_content(content) -> list[dict]:

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -426,8 +426,7 @@ class TestStripContextPreamble:
 
     def test_codex_title_cut_inside_the_pointer_names_the_file(self):
         # Verbatim session/list title from codex-acp 0.16.0: the pointer
-        # fills its 117 characters, so none of the question survives. The
-        # other cut tests below exercise the matcher on shapes beyond this one.
+        # fills its 117 characters, so none of the question survives.
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '' "
@@ -435,7 +434,123 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "analysis.py"
 
-    def test_title_cut_inside_a_quoted_value_names_the_file(self):
+    # The titles below are built from a pointer shaped like extension.py's
+    # and truncated the way each agent truncates, so each is one the picker
+    # can actually receive.
+
+    def test_codex_title_names_the_file_relative_to_the_directory(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "notebooks", "notebooks/eda.ipynb", "python", "python3",
+            "Python 3 (ipykernel)", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "eda.ipynb"
+
+    def test_codex_title_cut_inside_the_file_name_shows_the_partial_name(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "reports", "reports/2026-q3-regional-summary.ipynb", "python",
+            question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "2026-q3-regional-su..."
+
+    def test_codex_title_cut_before_the_file_name_names_the_directory(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "projects/analytics", "projects/analytics/revenue.ipynb", "python",
+            question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "projects/analytics"
+
+    def test_codex_title_file_outside_the_directory_keeps_its_path(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "notebooks", "data/load.py", "python", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "data/load.py"
+
+    def test_codex_title_file_named_like_the_start_of_the_directory_keeps_its_name(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "notes-archive", "notes", "python", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "notes"
+
+    def test_codex_title_cut_before_any_file_names_the_directory(self):
+        # No document focused (for example the launcher): the pointer has a
+        # directory and a language but no file.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "notebooks/experiments/2026", language="python",
+            question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "notebooks/experiments/2026"
+
+    def test_codex_title_cut_inside_the_file_label_names_the_directory(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "home/analyst/projects/2026/quarterly",
+            "home/analyst/projects/2026/quarterly/a.ipynb", "python", "python3",
+            "Python 3 (ipykernel)", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "home/analyst/projects/2026/quarterly"
+
+    def test_codex_title_cut_inside_the_kernel_label_with_no_directory_is_empty(self):
+        # Notebook generation sends no file and an empty directory.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "", language="python", kernel="python3", display="Python 3 (ipykernel)",
+            question="Create a notebook that plots revenue",
+        ))
+        assert _strip_context_preamble(title) == ""
+
+    def test_codex_title_cut_inside_the_directory_is_empty(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "home/analyst/projects/2026/quarterly-revenue-review/regional",
+            "home/analyst/projects/2026/quarterly-revenue-review/regional/a.ipynb",
+            "python", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == ""
+
+    def test_codex_title_keeps_a_truncated_question(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title(_prompt(
+            "", language="python",
+            question="Run analysis.py and check whether the revenue totals "
+            "look right, then fix anything that is wrong",
+        ))
+        assert _strip_context_preamble(title) == "Run analysi..."
+
+    def test_claude_code_acp_title_names_the_file(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _claude_code_acp_title(_prompt(
+            "", "analysis.ipynb", "python", "python3", "Python 3 (ipykernel)",
+            question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == "analysis.ipynb"
+
+    def test_claude_code_acp_title_cut_inside_the_file_name(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _claude_code_acp_title(_prompt(
+            "", "quarterly-revenue-review-by-region-and-product-line.ipynb",
+            "python", question="Summarize the data",
+        ))
+        assert _strip_context_preamble(title) == (
+            "quarterly-revenue-review-by-region-and-produ\u2026"
+        )
+
+    def test_hoisted_slash_command_before_the_pointer_is_kept(self):
+        # assemble_query moves a custom command in front of the context lines.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = _codex_title("/analyze\n" + _prompt(
+            "", "analysis.py", "python", question="",
+        ))
+        assert _strip_context_preamble(title) == "/analyze"
+
+    # Shapes the agents do not produce, pinning the matcher on its own.
+
+    def test_cut_inside_a_quoted_value_names_the_file(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '/w' "
@@ -444,7 +559,7 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "nb.ipynb"
 
-    def test_title_cut_at_a_segment_boundary_names_the_file(self):
+    def test_cut_at_a_segment_boundary_names_the_file(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '/w' "
@@ -452,7 +567,7 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "nb.ipynb"
 
-    def test_title_cut_inside_the_kernel_display_name_names_the_file(self):
+    def test_cut_inside_the_kernel_display_name_names_the_file(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '' "
@@ -461,59 +576,6 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "a.ipynb"
 
-    def test_title_cut_inside_the_file_path_shows_the_partial_path(self):
-        # The usual codex shape: the file value is a path from the Jupyter
-        # root, so the cut often lands inside it.
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "Additional context: Current directory open in Jupyter is: "
-            "'projects/analytics' and current file is: 'projects/analytics/rev..."
-        )
-        assert _strip_context_preamble(title) == "projects/analytics/rev..."
-
-    def test_title_cut_before_any_file_is_empty(self):
-        # No document focused (for example the launcher), so the pointer has
-        # a directory and a language but no file.
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "Additional context: Current directory open in Jupyter is: "
-            "'notebooks/experiments' and active programming language is:..."
-        )
-        assert _strip_context_preamble(title) == ""
-
-    def test_title_cut_inside_the_directory_is_empty(self):
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "Additional context: Current directory open in Jupyter is: "
-            "'home/analyst/projects/2026/quarterly-revenue-review/regional..."
-        )
-        assert _strip_context_preamble(title) == ""
-
-    def test_claude_code_acp_ellipsis_marks_a_cut(self):
-        # claude-code-acp truncates at 127 characters plus a single U+2026.
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "Additional context: Current directory open in Jupyter is: '' "
-            "and current file is: 'analysis.ipynb' "
-            "and active programming language is: 'python' with act\u2026"
-        )
-        assert _strip_context_preamble(title) == "analysis.ipynb"
-
-    def test_segment_text_without_a_marker_is_the_question(self):
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = "Additional context: Current directory open in Jupyter is: '' with"
-        assert _strip_context_preamble(title) == "with"
-
-    def test_truncated_question_keeps_its_marker(self):
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "Additional context: Current directory open in Jupyter is: '' "
-            "Run analysis.py and check whether the revenue totals look..."
-        )
-        assert _strip_context_preamble(title) == (
-            "Run analysis.py and check whether the revenue totals look..."
-        )
-
     def test_question_ending_in_an_ellipsis_is_not_mistaken_for_a_cut(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
@@ -521,6 +583,11 @@ class TestStripContextPreamble:
             "and current file is: 'a.py' Wait for it..."
         )
         assert _strip_context_preamble(title) == "Wait for it..."
+
+    def test_segment_text_without_a_marker_is_the_question(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = "Additional context: Current directory open in Jupyter is: '' with"
+        assert _strip_context_preamble(title) == "with"
 
     def test_parenthesized_question_without_a_kernel_is_kept(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
@@ -549,15 +616,6 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "(quick one about the loop in..."
 
-    def test_pointer_after_a_hoisted_slash_command_is_stripped(self):
-        # assemble_query moves a custom command in front of the context lines.
-        from notebook_intelligence.acp_agent import _strip_context_preamble
-        title = (
-            "/analyze Additional context: Current directory open in Jupyter is: '' "
-            "and current file is: 'a.py' and active programming langu..."
-        )
-        assert _strip_context_preamble(title) == "/analyze"
-
     def test_untruncated_pointer_with_no_question_names_the_file(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
@@ -565,6 +623,35 @@ class TestStripContextPreamble:
             "and current file is: 'nb.ipynb'"
         )
         assert _strip_context_preamble(title) == "nb.ipynb"
+
+
+def _prompt(directory, file="", language="", kernel="", display="", question=""):
+    """A first prompt shaped like extension.py's: the pointer, then the question."""
+    from notebook_intelligence.claude_sessions import NBI_CONTEXT_PREFIX
+    pointer = f"{NBI_CONTEXT_PREFIX} '{directory}'"
+    if file:
+        pointer += f" and current file is: '{file}'"
+    if language:
+        pointer += f" and active programming language is: '{language}'"
+    if kernel:
+        pointer += f" with active kernel name: '{kernel}'"
+    if display:
+        pointer += f" ({display})"
+    return f"{pointer}\n{question}" if question else pointer
+
+
+def _codex_title(prompt):
+    """codex-acp's session title for ASCII text (it counts graphemes): newlines
+    as spaces, 117 characters plus "..."."""
+    text = prompt.replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= 120 else text[:117] + "..."
+
+
+def _claude_code_acp_title(prompt):
+    """claude-code-acp's sanitizeTitle for ASCII text (it counts UTF-16 units):
+    whitespace collapsed, 127 characters plus U+2026."""
+    text = " ".join(prompt.split())
+    return text if len(text) <= 128 else text[:127] + "\u2026"
 
 
 class TestSingleFlight:

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -426,7 +426,8 @@ class TestStripContextPreamble:
 
     def test_codex_title_cut_inside_the_pointer_names_the_file(self):
         # Verbatim session/list title from codex-acp 0.16.0: the pointer
-        # fills its 117 characters, so none of the question survives.
+        # fills its 117 characters, so none of the question survives. The
+        # other cut tests below exercise the matcher on shapes beyond this one.
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '' "
@@ -460,13 +461,48 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "a.ipynb"
 
-    def test_title_cut_inside_the_file_name_keeps_the_title(self):
+    def test_title_cut_inside_the_file_path_shows_the_partial_path(self):
+        # The usual codex shape: the file value is a path from the Jupyter
+        # root, so the cut often lands inside it.
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: "
-            "'/home/user/projects' and current file is: 'notebooks/ana..."
+            "'projects/analytics' and current file is: 'projects/analytics/rev..."
         )
-        assert _strip_context_preamble(title) == title
+        assert _strip_context_preamble(title) == "projects/analytics/rev..."
+
+    def test_title_cut_before_any_file_is_empty(self):
+        # No document focused (for example the launcher), so the pointer has
+        # a directory and a language but no file.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: "
+            "'notebooks/experiments' and active programming language is:..."
+        )
+        assert _strip_context_preamble(title) == ""
+
+    def test_title_cut_inside_the_directory_is_empty(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: "
+            "'home/analyst/projects/2026/quarterly-revenue-review/regional..."
+        )
+        assert _strip_context_preamble(title) == ""
+
+    def test_claude_code_acp_ellipsis_marks_a_cut(self):
+        # claude-code-acp truncates at 127 characters plus a single U+2026.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'analysis.ipynb' "
+            "and active programming language is: 'python' with act\u2026"
+        )
+        assert _strip_context_preamble(title) == "analysis.ipynb"
+
+    def test_segment_text_without_a_marker_is_the_question(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = "Additional context: Current directory open in Jupyter is: '' with"
+        assert _strip_context_preamble(title) == "with"
 
     def test_truncated_question_keeps_its_marker(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
@@ -502,6 +538,17 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "(quick one about the loop in..."
 
+    def test_truncated_parenthesized_question_after_a_display_name_is_kept(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '/w' "
+            "and current file is: 'nb.ipynb' "
+            "and active programming language is: 'python' "
+            "with active kernel name: 'python3' (Python 3 (ipykernel)) "
+            "(quick one about the loop in..."
+        )
+        assert _strip_context_preamble(title) == "(quick one about the loop in..."
+
     def test_pointer_after_a_hoisted_slash_command_is_stripped(self):
         # assemble_query moves a custom command in front of the context lines.
         from notebook_intelligence.acp_agent import _strip_context_preamble
@@ -511,7 +558,7 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "/analyze"
 
-    def test_full_pointer_with_no_question_names_the_file(self):
+    def test_untruncated_pointer_with_no_question_names_the_file(self):
         from notebook_intelligence.acp_agent import _strip_context_preamble
         title = (
             "Additional context: Current directory open in Jupyter is: '/w' "

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -413,6 +413,112 @@ class TestStripContextPreamble:
         )
         assert _strip_context_preamble(title) == "What does this cell do?"
 
+    def test_joined_form_with_language_and_kernel(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '/w' "
+            "and current file is: 'nb.ipynb' "
+            "and active programming language is: 'python' "
+            "with active kernel name: 'python3' (Python 3 (ipykernel)) "
+            "What does this cell do?"
+        )
+        assert _strip_context_preamble(title) == "What does this cell do?"
+
+    def test_codex_title_cut_inside_the_pointer_names_the_file(self):
+        # Verbatim session/list title from codex-acp 0.16.0: the pointer
+        # fills its 117 characters, so none of the question survives.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'analysis.py' and active programmin..."
+        )
+        assert _strip_context_preamble(title) == "analysis.py"
+
+    def test_title_cut_inside_a_quoted_value_names_the_file(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '/w' "
+            "and current file is: 'nb.ipynb' "
+            "and active programming language is: 'pyt..."
+        )
+        assert _strip_context_preamble(title) == "nb.ipynb"
+
+    def test_title_cut_at_a_segment_boundary_names_the_file(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '/w' "
+            "and current file is: 'nb.ipynb'..."
+        )
+        assert _strip_context_preamble(title) == "nb.ipynb"
+
+    def test_title_cut_inside_the_kernel_display_name_names_the_file(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'a.ipynb' "
+            "with active kernel name: 'python3' (Python 3 (ipyk..."
+        )
+        assert _strip_context_preamble(title) == "a.ipynb"
+
+    def test_title_cut_inside_the_file_name_keeps_the_title(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: "
+            "'/home/user/projects' and current file is: 'notebooks/ana..."
+        )
+        assert _strip_context_preamble(title) == title
+
+    def test_truncated_question_keeps_its_marker(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "Run analysis.py and check whether the revenue totals look..."
+        )
+        assert _strip_context_preamble(title) == (
+            "Run analysis.py and check whether the revenue totals look..."
+        )
+
+    def test_question_ending_in_an_ellipsis_is_not_mistaken_for_a_cut(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'a.py' Wait for it..."
+        )
+        assert _strip_context_preamble(title) == "Wait for it..."
+
+    def test_parenthesized_question_without_a_kernel_is_kept(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'a.py' (quick one) what does line 3 do?"
+        )
+        assert _strip_context_preamble(title) == "(quick one) what does line 3 do?"
+
+    def test_truncated_parenthesized_question_without_a_kernel_is_kept(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'a.py' (quick one about the loop in..."
+        )
+        assert _strip_context_preamble(title) == "(quick one about the loop in..."
+
+    def test_pointer_after_a_hoisted_slash_command_is_stripped(self):
+        # assemble_query moves a custom command in front of the context lines.
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "/analyze Additional context: Current directory open in Jupyter is: '' "
+            "and current file is: 'a.py' and active programming langu..."
+        )
+        assert _strip_context_preamble(title) == "/analyze"
+
+    def test_full_pointer_with_no_question_names_the_file(self):
+        from notebook_intelligence.acp_agent import _strip_context_preamble
+        title = (
+            "Additional context: Current directory open in Jupyter is: '/w' "
+            "and current file is: 'nb.ipynb'"
+        )
+        assert _strip_context_preamble(title) == "nb.ipynb"
+
 
 class TestSingleFlight:
     """The ACP session runs one prompt at a time; a second concurrent turn


### PR DESCRIPTION
## Summary

In ACP mode, the **Resume session** picker labels Codex sessions with a fragment of NBI's context pointer, for example `and active programmin...`, instead of anything that identifies the session. Every session started from the same notebook looks identical and meaningless.

Listing real stored sessions through the pinned `codex-acp` 0.16.0 showed why. Codex titles a session with its first prompt, and `codex-acp` collapses newlines and cuts the title at 117 characters plus `...`. NBI's directory pointer comes before the question, and once it names a file and a language it is longer than that limit. So the stored title never contains any of the user's question, and the matcher in `_strip_context_preamble`, which knew only the directory and current-file segments, let the rest of the pointer through.

## Solution

The fix is in how the preview is derived. The prompt sent to the agent is unchanged.

- **Match the whole pointer.** A module-level regex matches every segment `extension.py` can emit: directory, current file, language, kernel name, and kernel display name (one level of nested parentheses, as in `Python 3 (ipykernel)`).
- **Recognize a cut pointer.** A title ending in `codex-acp`'s `...` or `claude-code-acp`'s single `…` (U+2026, after 127 characters) is truncated. In a truncated title a quoted value may run to the end without its closing quote, and a tail that is the start of another segment label counts as part of the pointer.
- **Pick the most useful label when no question survives.**
  - The current file, relative to the open directory. The frontend sends paths from the Jupyter root, so a notebook in `projects/analytics` would otherwise be labeled with the folder name.
  - The partial file name with the agent's marker, when the cut lands inside it.
  - The directory, when the cut leaves none of the file's own name or comes before any file (for example with the launcher focused), provided the title holds the whole directory.
  - An empty preview otherwise. The picker and the resume notice already hide an empty preview.
- **Unchanged behavior.** Newline-form titles are handled as before, a pointer after a hoisted slash command is still stripped, and an untruncated title with no file and no question still falls back to the title, as the existing test expects.

## Testing

- **Unit tests.** `TestStripContextPreamble` grows from 5 to 27 tests.
  - **Agent-shaped cases.** Titles are built by helpers that mirror `extension.py`'s pointer and each agent's truncation (`_prompt`, `_codex_title`, `_claude_code_acp_title`). They cover:
    - a file relative to the directory, a partial file name, a directory fallback, a file outside the directory, and no file;
    - a cut inside the directory, the file label, and the kernel label;
    - a surviving truncated question, a `claude-code-acp` title, and a hoisted slash command.
  - **Verbatim title.** One test uses the exact title `codex-acp` returned for a real session.
  - **Matcher-only shapes.** A separate group pins cuts inside quoted values and display names, questions ending in `...`, and questions that start with parentheses.
- **Mutation checks.** 21 mutants run against a copy of the repo. 20 fail at least one test; the survivor, `file is None` in place of `not file`, gives the same output for every input. They cover:
  - each segment label removed from the cut check;
  - the cut check without the marker, and a dots-only marker;
  - strict closing quotes;
  - no display-name group, or a repeating one;
  - an anchored match;
  - no relative path, and no directory fallback.
- **Fuzzing.** Reviewers ran about 1.2M generated titles covering notebook, text-file, launcher, Explain/Fix This, and notebook-generation shapes, cut as each agent cuts them. No wrong preview came back for anything the frontend can send.
- **Suites.** `pytest tests/ --ignore=tests/test_claude_client.py` (1777 passed), `jlpm tsc --noEmit`, stylelint, eslint, and `jlpm jest` (423 passed).
- **Live check.** JupyterLab 4.6 ran with an isolated home directory, ACP mode enabled, and the real `npx -y @zed-industries/codex-acp@0.16.0`. It was pointed at three stored Codex sessions from a demo workspace and given a placeholder API key; listing sessions makes no model call. After opening the NBI sidebar and the Resume session picker, the previews were:

| | This branch | `main` |
| --- | --- | --- |
| Session 1 | `analysis.py` | `and active programmin...` |
| Session 2 | `analysis.py` | `and active programmin...` |
| Session 3 | `analysis.py` | `and active programmin...` |

No console errors on either run. The placeholder credential Codex wrote to its `auth.json` was deleted afterwards.

## Risks / follow-ups

- **Same-file sessions still look alike.** Sessions started from the same file share a label and are told apart by time and ID. Getting the actual question into the title would mean putting it before the context lines in ACP prompts, which changes the prompt the agent sees, so it is not part of this PR.
- **Apostrophes in names.** A directory or file name containing `'` still ends the match early, as it did before.
- **Markdown in the resume notice.** The notice wraps the preview in `_..._`, so a name such as `__init__.py` renders with its underscores consumed. Question previews already had this; file names make it more visible. Escaping the preview there would cover both the Claude and ACP notices.
- **Non-BMP characters at the cut.** `claude-code-acp` cuts by UTF-16 units, so an emoji at the cut can leave a lone surrogate that displays as a replacement character.
- **Long picker previews.** A long name with no break characters is clipped without an ellipsis in the picker; `overflow-wrap: anywhere` on the preview would help.
- **Changelog.** No entry here, to avoid a heading conflict with #420's new `5.4.1` section. Happy to add one once that lands.

No issue was filed for this. It came up while checking the 5.4 release notes against the code, and the details are above.
